### PR TITLE
Inline headers in ROOT dictionaries

### DIFF
--- a/display/CMakeLists.txt
+++ b/display/CMakeLists.txt
@@ -31,7 +31,8 @@ endif(ROOT_Eve_LIBRARY)
 
 # Suck up all of the source files.  This isn't good CMAKE practice,
 # but it makes maintaining this file easier.
-file(GLOB_RECURSE source *.cxx)
+file(GLOB_RECURSE source RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cxx)
+
 
 # Suck up the output definition files from the edepsim library.  Don't
 # ever do this!!!!  The I/O should really be broken into a separate

--- a/display/CMakeLists.txt
+++ b/display/CMakeLists.txt
@@ -31,7 +31,7 @@ endif(ROOT_Eve_LIBRARY)
 
 # Suck up all of the source files.  This isn't good CMAKE practice,
 # but it makes maintaining this file easier.
-file(GLOB_RECURSE source RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cxx)
+file(GLOB_RECURSE source *.cxx)
 
 
 # Suck up the output definition files from the edepsim library.  Don't
@@ -51,11 +51,13 @@ message("The stolen source is ${stolenSource}")
 # Build the dictionary for the i/o classes.
 ROOT_GENERATE_DICTIONARY(G__edepdisp
   TEventChangeManager.hxx
+  OPTIONS -inlineInputHeader
   LINKDEF edepdisp_LinkDef.h)
 
 # Build the dictionary for the i/o classes.
 ROOT_GENERATE_DICTIONARY(G__edepdisp_edepsim
   ${stolenIncludes}
+  OPTIONS -inlineInputHeader
   LINKDEF ../src/edepsim_LinkDef.h)
 
 # Build the library.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Suck up all of the .cc files for the source.  This isn't good CMAKE
 # practice, but it makes maintaining this file easier.
-file(GLOB_RECURSE source RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cc)
-file(GLOB_RECURSE includes RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} EDepSim*.hh TG4*.h)
+file(GLOB_RECURSE source *.cc)
+file(GLOB_RECURSE includes EDepSim*.hh TG4*.h)
 
 # Make sure the current directories are available for the root
 # dictionary generation.
@@ -10,6 +10,7 @@ include_directories(${CMAKE_CURRENT_LIST_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 # Build the dictionary for the i/o classes.
 ROOT_GENERATE_DICTIONARY(G__edepsim
   TG4PrimaryVertex.h TG4Trajectory.h TG4HitSegment.h TG4Event.h
+  OPTIONS -inlineInputHeader
   LINKDEF edepsim_LinkDef.h)
 
 # Where the macro files can be found.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Suck up all of the .cc files for the source.  This isn't good CMAKE
 # practice, but it makes maintaining this file easier.
-file(GLOB_RECURSE source *.cc)
-file(GLOB_RECURSE includes EDepSim*.hh TG4*.h)
+file(GLOB_RECURSE source RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cc)
+file(GLOB_RECURSE includes RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} EDepSim*.hh TG4*.h)
 
 # Make sure the current directories are available for the root
 # dictionary generation.

--- a/tools/plotEDepSim.C
+++ b/tools/plotEDepSim.C
@@ -9,7 +9,11 @@
 
 #include <TGeoManager.h>
 
+
 #include "plotEDepSim.h"
+
+#include <iostream>
+
 
 // Dummy.  Could be used if initialization is required.
 void plotEDepSim() {}


### PR DESCRIPTION
Fixes #1 

ROOT6 dictionaries are apparently generated with absolute paths to header files hard coded.  There's some new autoloading mechanism which wants these headers.  If the build source area goes away, these become dangling references.  

One solution is to tell `rootcling` to inline the header file contents which this PR does by passing the option `-inlineInputHeader` through the `cmake` macro that runs `rootcling`.  

Another solution is maybe to use `-noIncludePaths`.  I guess this is good that it makes the dictionaries smaller but at the cost that one has to install the header files and set `ROOT_INCLUDE_PATH`.  This doesn't seem like a good tradeoff.