### PR TITLE
Arbitrary EM Fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,46 @@ assumed that the units are `volt/cm`.
 The possible units for the magnetic field are `tesla`, `gauss`, `T`, and
 `G`.  If no units are provided, it is assumed that the units are `tesla`.
 
+Arbitrary electric and magnetic fields can be set using the `ArbEField` and
+`BField` auxiliary types. The value for each is the name of the grid file which
+specifies the value of the field at a set of X, Y, and Z grid points (global
+coordinates).
+
+```
+<auxiliary auxtype="ArbEField" auxvalue="efield_grid_file.txt"/>
+<auxiliary auxtype="ArbBField" auxvalue="bfield_grid_file.txt"/>
+```
+
+The grid file is specified in the following format:
+
+```
+#First row is a header defining the origin offset and grid spacing
+#in each position coordinate X, Y, Z then hX, hY, hZ.
+-2600.00 -4200.00 12300.00 200.00 200.00 200.00
+
+#Next, each row contains one grid point: x,y,z,fx,fy,fz,f
+0.00 0.00 000.00 0.40 0.00 0.00 0.40
+0.00 0.00 200.00 0.40 0.40 0.00 0.57
+0.00 0.00 400.00 0.40 0.40 0.40 0.69
+...and so on...
+```
+
+The position, XYZ, is specified in `mm`, the electric field is specified in
+`V/cm`, and the magnetic field is specified in `T`. The grid spacing for each
+axis can be different.
+
+FX, FY, FZ are the magnitudes of the fields in the X,Y,Z directions and F is the
+total magnitude of the field vector. The Z coordinate iterates first, then Y, and
+finally X when incrementing the lines.
+
+To save space, the position of each point is not stored. Instead the position is
+calculated using the offset and the index of the array: `x = hx * i + offset_x`, where
+hx is the grid spacing in x, i is the ith element of the array, and offset_x is
+the offset specified in the first line for the x coordinate.
+
+Comment lines starting with the `#` character are supported in the grid file. They
+will be ignored when parsing the file.
+
 #### Auxiliary field to set the drawing color for the volume
 
 The display properties for the logical volume can be set using the `Color`

--- a/src/EDepSimArbEMField.cc
+++ b/src/EDepSimArbEMField.cc
@@ -76,11 +76,9 @@ EDepSim::ArbEMField::~ArbEMField()
 void EDepSim::ArbEMField::GetFieldValue(const G4double pos[4], G4double *field) const
 {
     //GetFieldValue always expects an array with six elements for both the EField
-    //and BField, even if it only fills one of them.
+    //and BField, even if it only fills one of the fields.
     double tmp_bfield[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     double tmp_efield[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-
-    //std::cout << "pos: (" << pos[0] << ", " << pos[1] << ", " << pos[2] << std::endl;
 
     if(bfield != nullptr)
         bfield->GetFieldValue(pos, tmp_bfield);
@@ -88,6 +86,8 @@ void EDepSim::ArbEMField::GetFieldValue(const G4double pos[4], G4double *field) 
     if(efield != nullptr)
         efield->GetFieldValue(pos, tmp_efield);
 
+    //Geant4 convention is the first three elements are Bx, By, Bz
+    //and the next three are Ex, Ey, Ez
     field[0] = tmp_bfield[0];
     field[1] = tmp_bfield[1];
     field[2] = tmp_bfield[2];
@@ -95,9 +95,4 @@ void EDepSim::ArbEMField::GetFieldValue(const G4double pos[4], G4double *field) 
     field[3] = tmp_efield[3];
     field[4] = tmp_efield[4];
     field[5] = tmp_efield[5];
-
-    //std::cout << "field: ";
-    //for(int i = 0; i < 6; ++i)
-    //    std::cout << field[i] << " ";
-    //std::cout << std::endl;
 }

--- a/src/EDepSimArbEMField.hh
+++ b/src/EDepSimArbEMField.hh
@@ -26,60 +26,45 @@
 //
 // $Id$
 //
-// 
-// class EDepSim::UniformElectricField
+//
+// class EDepSim::ArbEMField
 //
 // Class description:
 //
-// Class for creation of Uniform electric Magnetic Field.
-
+// Class for storing and handling an arbitrary EM field.
+//
 // History:
-// - 30.01.97 V.Grichine, Created.
+// - 2020.04.14 A.Cudd created
 // -------------------------------------------------------------------
 
-#ifndef G4UNIFORMELECTRICFIELD_HH
-#define G4UNIFORMELECTRICFIELD_HH
+#ifndef EDEPSIMARBEMFIELD_H
+#define EDEPSIMARBEMFIELD_H
 
 #include "G4Types.hh"
-#include "G4ThreeVector.hh"
-#include "G4ElectricField.hh"
+#include "G4ElectroMagneticField.hh"
 
-namespace EDepSim {class UniformField;}
+namespace EDepSim { class ArbEMField; }
 
-class EDepSim::UniformField : public G4ElectricField
+class EDepSim::ArbEMField : public G4ElectroMagneticField
 {
-  public:
+    public:
+        ArbEMField();
+        ArbEMField(G4ElectroMagneticField* efield_in, G4ElectroMagneticField* bfield_in);
 
-    UniformField();
+        ArbEMField(const ArbEMField& cpy);
+        ArbEMField& operator=(const ArbEMField& rhs);
 
-    /// Define a uniform magnetic field.  The electric field will be set to
-    /// zero.  This is equivalent to G4UniformMagneticField().  
-    UniformField(const G4ThreeVector bField);
+        virtual ~ArbEMField();
 
-    /// Define a uniform magnetic and electric field.
-    UniformField(const G4ThreeVector bField, const G4ThreeVector eField);
+        virtual void GetFieldValue(const G4double pos[4], G4double *field) const;
+        virtual G4bool DoesFieldChangeEnergy() const { return true; };
 
-    virtual ~UniformField() ;
+        void SetEField(G4ElectroMagneticField* efield_in) { efield = efield_in; };
+        void SetBField(G4ElectroMagneticField* bfield_in) { bfield = bfield_in; };
 
-    // Copy constructor and assignment operator
-    UniformField(const UniformField &p);
-    UniformField& operator = (const UniformField &p);
-    
-    /// Provide the field value at a point [x,y,z,t].  The field follows the
-    /// G4 standard so that the magnetic field is in field[0], field[1], and
-    /// field[2] while the electric field is in field[3], field[3], and
-    /// field[5].
-    virtual void GetFieldValue(const G4double pos[4], G4double *field) const;
-
-    virtual void SetBField(const G4ThreeVector bField);
-    virtual void SetEField(const G4ThreeVector eField);
-
-  private:
-  
-    /// The field components follows the G4 standard so that the magnetic
-    /// field is in [0], [1], and [2] while the electric field is in [3], [4],
-    /// and [5].
-    G4double fFieldComponents[6] ;
+    private:
+        G4ElectroMagneticField* efield;
+        G4ElectroMagneticField* bfield;
 };
 
 #endif

--- a/src/EDepSimArbElecField.cc
+++ b/src/EDepSimArbElecField.cc
@@ -47,13 +47,11 @@ bool EDepSim::ArbElecField::ReadFile(const std::string& fname)
 
     if(!fin.is_open())
     {
-        //std::cout << "[ERROR]: Can't read " << fname << std::endl;
         EDepSimError("Can't read " << fname << std::endl);
         return false;
     }
     else
     {
-        //std::cout << "Reading " << fname << " ..." << std::endl;
         EDepSimLog("Reading " << fname << " ...");
         int xcount{-1}, ycount{-1}, zcount{-1};
         double xcurr{0}, ycurr{0}, zcurr{0};
@@ -122,7 +120,7 @@ void EDepSim::ArbElecField::GetFieldValue(const G4double pos[4], G4double* field
     const double y = pos[1];
     const double z = pos[2];
 
-    EDepSim::Bicubic interp;
+    EDepSim::Cubic interp;
     field[3] = interp.interpolate(x, y, z, m_field_x, m_delta[0], m_delta[1], m_delta[2], m_offset[0], m_offset[1], m_offset[2]);
     field[4] = interp.interpolate(x, y, z, m_field_y, m_delta[0], m_delta[1], m_delta[2], m_offset[0], m_offset[1], m_offset[2]);
     field[5] = interp.interpolate(x, y, z, m_field_z, m_delta[0], m_delta[1], m_delta[2], m_offset[0], m_offset[1], m_offset[2]);
@@ -130,10 +128,6 @@ void EDepSim::ArbElecField::GetFieldValue(const G4double pos[4], G4double* field
 
 void EDepSim::ArbElecField::PrintInfo() const
 {
-    //std::cout << "Printing values for electric field." << std::endl;
-    //std::cout << "m_filename : " << m_filename << std::endl
-    //          << "m_offset   : " << m_offset[0] << ", " << m_offset[1] << ", " << m_offset[2] << std::endl
-    //          << "m_delta    : " << m_delta[0] << ", " << m_delta[1] << ", " << m_delta[2] << std::endl;
     EDepSimLog("Printing values for electric field.");
     EDepSimLog("m_filename : " << m_filename
               << "\nm_offset   : " << m_offset[0] << ", " << m_offset[1] << ", " << m_offset[2]

--- a/src/EDepSimArbElecField.cc
+++ b/src/EDepSimArbElecField.cc
@@ -1,0 +1,141 @@
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+//
+//
+// Class for storing and handling an arbitrary electric field.
+//
+// History:
+// - 2020.04.14 A.Cudd created
+//
+// -------------------------------------------------------------------
+
+#include "EDepSimArbElecField.hh"
+
+EDepSim::ArbElecField::ArbElecField()
+{
+}
+
+bool EDepSim::ArbElecField::ReadFile(const std::string& fname)
+{
+    m_filename = fname;
+    std::fstream fin(fname, std::fstream::in);
+
+    if(!fin.is_open())
+    {
+        //std::cout << "[ERROR]: Can't read " << fname << std::endl;
+        EDepSimError("Can't read " << fname << std::endl);
+        return false;
+    }
+    else
+    {
+        //std::cout << "Reading " << fname << " ..." << std::endl;
+        EDepSimLog("Reading " << fname << " ...");
+        int xcount{-1}, ycount{-1}, zcount{-1};
+        double xcurr{0}, ycurr{0}, zcurr{0};
+        std::string line;
+
+        while(std::getline(fin >> std::ws, line))
+        {
+            std::stringstream ss(line);
+
+            if(ss.str().front() == '#')
+                continue;
+
+            ss >> m_offset[0] >> m_offset[1] >> m_offset[2]
+                >> m_delta[0] >> m_delta[1] >> m_delta[2];
+            break;
+        }
+
+        while(std::getline(fin >> std::ws, line))
+        {
+            double x{0}, y{0}, z{0}, fx{0}, fy{0}, fz{0}, f{0};
+            std::stringstream ss(line);
+
+            if(ss.str().front() == '#')
+                continue;
+
+            ss >> x >> y >> z >> fx >> fy >> fz >> f;
+
+            if(std::abs(x - xcurr) > 0.0 || xcount < 0)
+            {
+                xcurr = x;
+                xcount += 1;
+                ycount = -1;
+                m_field_x.emplace_back(std::vector<std::vector<double>>{});
+                m_field_y.emplace_back(std::vector<std::vector<double>>{});
+                m_field_z.emplace_back(std::vector<std::vector<double>>{});
+            }
+
+            if(std::abs(y - ycurr) > 0.0 || ycount < 0)
+            {
+                ycurr = y;
+                ycount += 1;
+                zcount = -1;
+                m_field_x[xcount].emplace_back(std::vector<double>{});
+                m_field_y[xcount].emplace_back(std::vector<double>{});
+                m_field_z[xcount].emplace_back(std::vector<double>{});
+            }
+
+            m_field_x[xcount][ycount].push_back(fx * (volt/cm));
+            m_field_y[xcount][ycount].push_back(fy * (volt/cm));
+            m_field_z[xcount][ycount].push_back(fz * (volt/cm));
+
+            if(std::abs(z - zcurr) > 0.0 || zcount < 0)
+            {
+                zcurr = z;
+                zcount += 1;
+            }
+        }
+    }
+
+    return true;
+}
+
+void EDepSim::ArbElecField::GetFieldValue(const G4double pos[4], G4double* field) const
+{
+    const double x = pos[0];
+    const double y = pos[1];
+    const double z = pos[2];
+
+    EDepSim::Bicubic interp;
+    field[3] = interp.interpolate(x, y, z, m_field_x, m_delta[0], m_delta[1], m_delta[2], m_offset[0], m_offset[1], m_offset[2]);
+    field[4] = interp.interpolate(x, y, z, m_field_y, m_delta[0], m_delta[1], m_delta[2], m_offset[0], m_offset[1], m_offset[2]);
+    field[5] = interp.interpolate(x, y, z, m_field_z, m_delta[0], m_delta[1], m_delta[2], m_offset[0], m_offset[1], m_offset[2]);
+}
+
+void EDepSim::ArbElecField::PrintInfo() const
+{
+    //std::cout << "Printing values for electric field." << std::endl;
+    //std::cout << "m_filename : " << m_filename << std::endl
+    //          << "m_offset   : " << m_offset[0] << ", " << m_offset[1] << ", " << m_offset[2] << std::endl
+    //          << "m_delta    : " << m_delta[0] << ", " << m_delta[1] << ", " << m_delta[2] << std::endl;
+    EDepSimLog("Printing values for electric field.");
+    EDepSimLog("m_filename : " << m_filename
+              << "\nm_offset   : " << m_offset[0] << ", " << m_offset[1] << ", " << m_offset[2]
+              << "\nm_delta    : " << m_delta[0] << ", " << m_delta[1] << ", " << m_delta[2]);
+}

--- a/src/EDepSimArbElecField.hh
+++ b/src/EDepSimArbElecField.hh
@@ -26,60 +26,53 @@
 //
 // $Id$
 //
-// 
-// class EDepSim::UniformElectricField
+//
+// class EDepSim::ArbElecField
 //
 // Class description:
 //
-// Class for creation of Uniform electric Magnetic Field.
-
+// Class for storing and handling an arbitrary electric field.
+//
 // History:
-// - 30.01.97 V.Grichine, Created.
+// - 2020.04.14 A.Cudd created
 // -------------------------------------------------------------------
 
-#ifndef G4UNIFORMELECTRICFIELD_HH
-#define G4UNIFORMELECTRICFIELD_HH
+#ifndef EDEPSIMARBELECFIELD_H
+#define EDEPSIMARBELECFIELD_H
+
+#include <array>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "G4Types.hh"
-#include "G4ThreeVector.hh"
 #include "G4ElectricField.hh"
+#include "G4SystemOfUnits.hh"
 
-namespace EDepSim {class UniformField;}
+#include "EDepSimLog.hh"
+#include "EDepSimInterpolator.hh"
 
-class EDepSim::UniformField : public G4ElectricField
+namespace EDepSim { class ArbElecField; }
+
+class EDepSim::ArbElecField : public G4ElectricField
 {
-  public:
+    public:
+        ArbElecField();
 
-    UniformField();
+        bool ReadFile(const std::string& fname);
+        void PrintInfo() const;
+        virtual void GetFieldValue(const G4double pos[4], G4double* field) const;
 
-    /// Define a uniform magnetic field.  The electric field will be set to
-    /// zero.  This is equivalent to G4UniformMagneticField().  
-    UniformField(const G4ThreeVector bField);
-
-    /// Define a uniform magnetic and electric field.
-    UniformField(const G4ThreeVector bField, const G4ThreeVector eField);
-
-    virtual ~UniformField() ;
-
-    // Copy constructor and assignment operator
-    UniformField(const UniformField &p);
-    UniformField& operator = (const UniformField &p);
-    
-    /// Provide the field value at a point [x,y,z,t].  The field follows the
-    /// G4 standard so that the magnetic field is in field[0], field[1], and
-    /// field[2] while the electric field is in field[3], field[3], and
-    /// field[5].
-    virtual void GetFieldValue(const G4double pos[4], G4double *field) const;
-
-    virtual void SetBField(const G4ThreeVector bField);
-    virtual void SetEField(const G4ThreeVector eField);
-
-  private:
-  
-    /// The field components follows the G4 standard so that the magnetic
-    /// field is in [0], [1], and [2] while the electric field is in [3], [4],
-    /// and [5].
-    G4double fFieldComponents[6] ;
+    private:
+        std::string m_filename;
+        std::array<double, 3> m_offset;
+        std::array<double, 3> m_delta;
+        std::vector<std::vector<std::vector<double>>> m_field_x;
+        std::vector<std::vector<std::vector<double>>> m_field_y;
+        std::vector<std::vector<std::vector<double>>> m_field_z;
 };
 
 #endif

--- a/src/EDepSimArbMagField.cc
+++ b/src/EDepSimArbMagField.cc
@@ -47,13 +47,11 @@ bool EDepSim::ArbMagField::ReadFile(const std::string& fname)
 
     if(!fin.is_open())
     {
-        //std::cout << "[ERROR]: Can't read " << fname << std::endl;
         EDepSimError("Can't read " << fname << std::endl);
         return false;
     }
     else
     {
-        //std::cout << "Reading " << fname << " ..." << std::endl;
         EDepSimLog("Reading " << fname << " ...");
         int xcount{-1}, ycount{-1}, zcount{-1};
         double xcurr{0}, ycurr{0}, zcurr{0};
@@ -122,7 +120,7 @@ void EDepSim::ArbMagField::GetFieldValue(const G4double pos[4], G4double* field)
     const double y = pos[1];
     const double z = pos[2];
 
-    EDepSim::Bicubic interp;
+    EDepSim::Cubic interp;
     field[0] = interp.interpolate(x, y, z, m_field_x, m_delta[0], m_delta[1], m_delta[2], m_offset[0], m_offset[1], m_offset[2]);
     field[1] = interp.interpolate(x, y, z, m_field_y, m_delta[0], m_delta[1], m_delta[2], m_offset[0], m_offset[1], m_offset[2]);
     field[2] = interp.interpolate(x, y, z, m_field_z, m_delta[0], m_delta[1], m_delta[2], m_offset[0], m_offset[1], m_offset[2]);
@@ -130,10 +128,6 @@ void EDepSim::ArbMagField::GetFieldValue(const G4double pos[4], G4double* field)
 
 void EDepSim::ArbMagField::PrintInfo() const
 {
-    //std::cout << "Printing values for magnetic field." << std::endl;
-    //std::cout << "m_filename : " << m_filename << std::endl
-    //          << "m_offset   : " << m_offset[0] << ", " << m_offset[1] << ", " << m_offset[2] << std::endl
-    //          << "m_delta    : " << m_delta[0] << ", " << m_delta[1] << ", " << m_delta[2] << std::endl;
     EDepSimLog("Printing values for magnetic field.");
     EDepSimLog("m_filename : " << m_filename
               << "\nm_offset   : " << m_offset[0] << ", " << m_offset[1] << ", " << m_offset[2]

--- a/src/EDepSimArbMagField.cc
+++ b/src/EDepSimArbMagField.cc
@@ -1,0 +1,141 @@
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+//
+//
+// Class for storing and handling an arbitrary magnetic field.
+//
+// History:
+// - 2020.04.14 A.Cudd created
+//
+// -------------------------------------------------------------------
+
+#include "EDepSimArbMagField.hh"
+
+EDepSim::ArbMagField::ArbMagField()
+{
+}
+
+bool EDepSim::ArbMagField::ReadFile(const std::string& fname)
+{
+    m_filename = fname;
+    std::fstream fin(fname, std::fstream::in);
+
+    if(!fin.is_open())
+    {
+        //std::cout << "[ERROR]: Can't read " << fname << std::endl;
+        EDepSimError("Can't read " << fname << std::endl);
+        return false;
+    }
+    else
+    {
+        //std::cout << "Reading " << fname << " ..." << std::endl;
+        EDepSimLog("Reading " << fname << " ...");
+        int xcount{-1}, ycount{-1}, zcount{-1};
+        double xcurr{0}, ycurr{0}, zcurr{0};
+        std::string line;
+
+        while(std::getline(fin >> std::ws, line))
+        {
+            std::stringstream ss(line);
+
+            if(ss.str().front() == '#')
+                continue;
+
+            ss >> m_offset[0] >> m_offset[1] >> m_offset[2]
+                >> m_delta[0] >> m_delta[1] >> m_delta[2];
+            break;
+        }
+
+        while(std::getline(fin >> std::ws, line))
+        {
+            double x{0}, y{0}, z{0}, fx{0}, fy{0}, fz{0}, f{0};
+            std::stringstream ss(line);
+
+            if(ss.str().front() == '#')
+                continue;
+
+            ss >> x >> y >> z >> fx >> fy >> fz >> f;
+
+            if(std::abs(x - xcurr) > 0.0 || xcount < 0)
+            {
+                xcurr = x;
+                xcount += 1;
+                ycount = -1;
+                m_field_x.emplace_back(std::vector<std::vector<double>>{});
+                m_field_y.emplace_back(std::vector<std::vector<double>>{});
+                m_field_z.emplace_back(std::vector<std::vector<double>>{});
+            }
+
+            if(std::abs(y - ycurr) > 0.0 || ycount < 0)
+            {
+                ycurr = y;
+                ycount += 1;
+                zcount = -1;
+                m_field_x[xcount].emplace_back(std::vector<double>{});
+                m_field_y[xcount].emplace_back(std::vector<double>{});
+                m_field_z[xcount].emplace_back(std::vector<double>{});
+            }
+
+            m_field_x[xcount][ycount].push_back(fx * tesla);
+            m_field_y[xcount][ycount].push_back(fy * tesla);
+            m_field_z[xcount][ycount].push_back(fz * tesla);
+
+            if(std::abs(z - zcurr) > 0.0 || zcount < 0)
+            {
+                zcurr = z;
+                zcount += 1;
+            }
+        }
+    }
+
+    return true;
+}
+
+void EDepSim::ArbMagField::GetFieldValue(const G4double pos[4], G4double* field) const
+{
+    const double x = pos[0];
+    const double y = pos[1];
+    const double z = pos[2];
+
+    EDepSim::Bicubic interp;
+    field[0] = interp.interpolate(x, y, z, m_field_x, m_delta[0], m_delta[1], m_delta[2], m_offset[0], m_offset[1], m_offset[2]);
+    field[1] = interp.interpolate(x, y, z, m_field_y, m_delta[0], m_delta[1], m_delta[2], m_offset[0], m_offset[1], m_offset[2]);
+    field[2] = interp.interpolate(x, y, z, m_field_z, m_delta[0], m_delta[1], m_delta[2], m_offset[0], m_offset[1], m_offset[2]);
+}
+
+void EDepSim::ArbMagField::PrintInfo() const
+{
+    //std::cout << "Printing values for magnetic field." << std::endl;
+    //std::cout << "m_filename : " << m_filename << std::endl
+    //          << "m_offset   : " << m_offset[0] << ", " << m_offset[1] << ", " << m_offset[2] << std::endl
+    //          << "m_delta    : " << m_delta[0] << ", " << m_delta[1] << ", " << m_delta[2] << std::endl;
+    EDepSimLog("Printing values for magnetic field.");
+    EDepSimLog("m_filename : " << m_filename
+              << "\nm_offset   : " << m_offset[0] << ", " << m_offset[1] << ", " << m_offset[2]
+              << "\nm_delta    : " << m_delta[0] << ", " << m_delta[1] << ", " << m_delta[2]);
+}

--- a/src/EDepSimArbMagField.hh
+++ b/src/EDepSimArbMagField.hh
@@ -26,60 +26,53 @@
 //
 // $Id$
 //
-// 
-// class EDepSim::UniformElectricField
+//
+// class EDepSim::ArbMagField
 //
 // Class description:
 //
-// Class for creation of Uniform electric Magnetic Field.
-
+// Class for storing and handling an arbitrary magnetic field.
+//
 // History:
-// - 30.01.97 V.Grichine, Created.
+// - 2020.04.14 A.Cudd created
 // -------------------------------------------------------------------
 
-#ifndef G4UNIFORMELECTRICFIELD_HH
-#define G4UNIFORMELECTRICFIELD_HH
+#ifndef EDEPSIMARBMAGFIELD_H
+#define EDEPSIMARBMAGFIELD_H
+
+#include <array>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "G4Types.hh"
-#include "G4ThreeVector.hh"
-#include "G4ElectricField.hh"
+#include "G4MagneticField.hh"
+#include <G4SystemOfUnits.hh>
 
-namespace EDepSim {class UniformField;}
+#include "EDepSimLog.hh"
+#include "EDepSimInterpolator.hh"
 
-class EDepSim::UniformField : public G4ElectricField
+namespace EDepSim { class ArbMagField; }
+
+class EDepSim::ArbMagField : public G4MagneticField
 {
-  public:
+    public:
+        ArbMagField();
 
-    UniformField();
+        bool ReadFile(const std::string& fname);
+        void PrintInfo() const;
+        virtual void GetFieldValue(const G4double pos[4], G4double* field) const;
 
-    /// Define a uniform magnetic field.  The electric field will be set to
-    /// zero.  This is equivalent to G4UniformMagneticField().  
-    UniformField(const G4ThreeVector bField);
-
-    /// Define a uniform magnetic and electric field.
-    UniformField(const G4ThreeVector bField, const G4ThreeVector eField);
-
-    virtual ~UniformField() ;
-
-    // Copy constructor and assignment operator
-    UniformField(const UniformField &p);
-    UniformField& operator = (const UniformField &p);
-    
-    /// Provide the field value at a point [x,y,z,t].  The field follows the
-    /// G4 standard so that the magnetic field is in field[0], field[1], and
-    /// field[2] while the electric field is in field[3], field[3], and
-    /// field[5].
-    virtual void GetFieldValue(const G4double pos[4], G4double *field) const;
-
-    virtual void SetBField(const G4ThreeVector bField);
-    virtual void SetEField(const G4ThreeVector eField);
-
-  private:
-  
-    /// The field components follows the G4 standard so that the magnetic
-    /// field is in [0], [1], and [2] while the electric field is in [3], [4],
-    /// and [5].
-    G4double fFieldComponents[6] ;
+    private:
+        std::string m_filename;
+        std::array<double, 3> m_offset;
+        std::array<double, 3> m_delta;
+        std::vector<std::vector<std::vector<double>>> m_field_x;
+        std::vector<std::vector<std::vector<double>>> m_field_y;
+        std::vector<std::vector<std::vector<double>>> m_field_z;
 };
 
 #endif

--- a/src/EDepSimInterpolator.cc
+++ b/src/EDepSimInterpolator.cc
@@ -1,0 +1,101 @@
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+//
+//
+// Class for routines for interpolating data on a regular grid.
+//
+// History:
+// - 2020.04.14 A.Cudd created
+//
+// -------------------------------------------------------------------
+
+#include "EDepSimInterpolator.hh"
+
+EDepSim::Bicubic::Bicubic()
+{
+}
+
+double EDepSim::Bicubic::interpolate(const double* point, const std::vector<std::vector<std::vector<double>>>& g,
+                   const double* delta, const double* offset) const
+{
+    return interpolate(point[0], point[1], point[2], g, delta[0], delta[1], delta[2], offset[0], offset[1], offset[2]);
+}
+
+double EDepSim::Bicubic::interpolate(double x, double y, double z, const std::vector<std::vector<std::vector<double>>>& g,
+                                     double hx, double hy, double hz, double xo, double yo, double zo) const
+{
+    double v = 0;
+
+    const int xsize = g.size();
+    const int ysize = g[0].size();
+    const int zsize = g[0][0].size();
+
+    const double xp = (x - xo) / hx;
+    const double yp = (y - yo) / hy;
+    const double zp = (z - zo) / hz;
+
+    const int x_idx = std::floor(xp);
+    const int y_idx = std::floor(yp);
+    const int z_idx = std::floor(zp);
+
+    for(auto i : {x_idx - 1, x_idx, x_idx + 1, x_idx + 2})
+    {
+        for(auto j : {y_idx - 1, y_idx, y_idx + 1, y_idx + 2})
+        {
+            for(auto k : {z_idx - 1, z_idx, z_idx + 1, z_idx + 2})
+            {
+                if(i < 0 || j < 0 || k < 0)
+                    continue;
+
+                if(i >= xsize || j >= ysize || k >= zsize)
+                    continue;
+
+                const double x_c = conv_kernel(xp - i);
+                const double y_c = conv_kernel(yp - j);
+                const double z_c = conv_kernel(zp - k);
+                v += g[i][j][k] * x_c * y_c * z_c;
+            }
+        }
+    }
+
+    return v;
+}
+
+double EDepSim::Bicubic::conv_kernel(double s) const
+{
+    double v = 0;
+    double z = std::abs(s);
+
+    if(0 <= z && z < 1)
+        v = 1 + (0.5) * z * z * (3 * z - 5);
+
+    else if(1 < z && z < 2)
+        v = 2 - z * (4 + 0.5 * z * (z - 5));
+
+    return v;
+}

--- a/src/EDepSimInterpolator.cc
+++ b/src/EDepSimInterpolator.cc
@@ -36,17 +36,17 @@
 
 #include "EDepSimInterpolator.hh"
 
-EDepSim::Bicubic::Bicubic()
+EDepSim::Cubic::Cubic()
 {
 }
 
-double EDepSim::Bicubic::interpolate(const double* point, const std::vector<std::vector<std::vector<double>>>& g,
+double EDepSim::Cubic::interpolate(const double* point, const std::vector<std::vector<std::vector<double>>>& g,
                    const double* delta, const double* offset) const
 {
     return interpolate(point[0], point[1], point[2], g, delta[0], delta[1], delta[2], offset[0], offset[1], offset[2]);
 }
 
-double EDepSim::Bicubic::interpolate(double x, double y, double z, const std::vector<std::vector<std::vector<double>>>& g,
+double EDepSim::Cubic::interpolate(double x, double y, double z, const std::vector<std::vector<std::vector<double>>>& g,
                                      double hx, double hy, double hz, double xo, double yo, double zo) const
 {
     double v = 0;
@@ -86,7 +86,7 @@ double EDepSim::Bicubic::interpolate(double x, double y, double z, const std::ve
     return v;
 }
 
-double EDepSim::Bicubic::conv_kernel(double s) const
+double EDepSim::Cubic::conv_kernel(double s) const
 {
     double v = 0;
     double z = std::abs(s);

--- a/src/EDepSimInterpolator.hh
+++ b/src/EDepSimInterpolator.hh
@@ -44,12 +44,12 @@
 #include <iostream>
 #include <vector>
 
-namespace EDepSim {class Bicubic;}
+namespace EDepSim {class Cubic;}
 
-class EDepSim::Bicubic
+class EDepSim::Cubic
 {
     public:
-        Bicubic();
+        Cubic();
 
         double interpolate(const double* point, const std::vector<std::vector<std::vector<double>>>& g,
                            const double* delta, const double* offset) const;

--- a/src/EDepSimInterpolator.hh
+++ b/src/EDepSimInterpolator.hh
@@ -26,60 +26,38 @@
 //
 // $Id$
 //
-// 
-// class EDepSim::UniformElectricField
+//
+// class EDepSim::Interpolator
 //
 // Class description:
 //
-// Class for creation of Uniform electric Magnetic Field.
-
+// Class for routines for interpolating data on a regular grid.
+//
 // History:
-// - 30.01.97 V.Grichine, Created.
+// - 2020.04.14 A.Cudd created
 // -------------------------------------------------------------------
 
-#ifndef G4UNIFORMELECTRICFIELD_HH
-#define G4UNIFORMELECTRICFIELD_HH
+#ifndef EDEPSIMINTERPOLATOR_HH
+#define EDEPSIMINTERPOLATOR_HH
 
-#include "G4Types.hh"
-#include "G4ThreeVector.hh"
-#include "G4ElectricField.hh"
+#include <cmath>
+#include <iostream>
+#include <vector>
 
-namespace EDepSim {class UniformField;}
+namespace EDepSim {class Bicubic;}
 
-class EDepSim::UniformField : public G4ElectricField
+class EDepSim::Bicubic
 {
-  public:
+    public:
+        Bicubic();
 
-    UniformField();
+        double interpolate(const double* point, const std::vector<std::vector<std::vector<double>>>& g,
+                           const double* delta, const double* offset) const;
+        double interpolate(double x, double y, double z, const std::vector<std::vector<std::vector<double>>>& g,
+                           double hx, double hy, double hz, double xo, double yo, double zo) const;
 
-    /// Define a uniform magnetic field.  The electric field will be set to
-    /// zero.  This is equivalent to G4UniformMagneticField().  
-    UniformField(const G4ThreeVector bField);
-
-    /// Define a uniform magnetic and electric field.
-    UniformField(const G4ThreeVector bField, const G4ThreeVector eField);
-
-    virtual ~UniformField() ;
-
-    // Copy constructor and assignment operator
-    UniformField(const UniformField &p);
-    UniformField& operator = (const UniformField &p);
-    
-    /// Provide the field value at a point [x,y,z,t].  The field follows the
-    /// G4 standard so that the magnetic field is in field[0], field[1], and
-    /// field[2] while the electric field is in field[3], field[3], and
-    /// field[5].
-    virtual void GetFieldValue(const G4double pos[4], G4double *field) const;
-
-    virtual void SetBField(const G4ThreeVector bField);
-    virtual void SetEField(const G4ThreeVector eField);
-
-  private:
-  
-    /// The field components follows the G4 standard so that the magnetic
-    /// field is in [0], [1], and [2] while the electric field is in [3], [4],
-    /// and [5].
-    G4double fFieldComponents[6] ;
+    private:
+        double conv_kernel(double s) const;
 };
 
 #endif

--- a/src/EDepSimUniformField.cc
+++ b/src/EDepSimUniformField.cc
@@ -36,6 +36,16 @@
 #include "EDepSimUniformField.hh"
 #include "G4PhysicalConstants.hh"
 
+EDepSim::UniformField::UniformField()
+{
+    fFieldComponents[0] = 0.0;
+    fFieldComponents[1] = 0.0;
+    fFieldComponents[2] = 0.0;
+    fFieldComponents[3] = 0.0;
+    fFieldComponents[4] = 0.0;
+    fFieldComponents[5] = 0.0;
+}
+
 EDepSim::UniformField::UniformField(
     const G4ThreeVector bField,
     const G4ThreeVector eField )
@@ -88,4 +98,18 @@ void EDepSim::UniformField::GetFieldValue (const G4double* /* position */,
     for (G4int i=0; i<6; ++i) {
         fieldBandE[i] = fFieldComponents[i];
     }
+}
+
+void EDepSim::UniformField::SetBField(const G4ThreeVector bField)
+{
+    fFieldComponents[0] = bField.x();
+    fFieldComponents[1] = bField.y();
+    fFieldComponents[2] = bField.z();
+}
+
+void EDepSim::UniformField::SetEField(const G4ThreeVector eField)
+{
+    fFieldComponents[3] = eField.x();
+    fFieldComponents[4] = eField.y();
+    fFieldComponents[5] = eField.z();
 }


### PR DESCRIPTION
Pull request to implement the ability for edep-sim to handle arbitrary EM fields specified using text files.

Several new classes were written to handle arbitrary electric and magnetic fields and inherit from their respective Geant4 classes. Modifications were made to the uniform field class to allow setting the electric or magnetic fields individually. A new class was created to handle the interpolation routine(s).

UserDetectorConstruction was modified to read/parse the configuration for arbitrary electric and magnetic fields. Constructing the fields and passing them to the FieldManager was modified to allow for both arbitrary and uniform fields.

Updated README with a section on how to set an arbitrary EM field and how the grid file is defined.

Let me know if there are any suggestions or changes for the implementation or organization.