### PR TITLE
Missing Dependencies on osx with geant 11.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Makefile
 *_C.*
 *.pcm
 *.png
+*darwin*
+*.json

--- a/app/edepSim.cc
+++ b/app/edepSim.cc
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <csignal>
 #include <cstdlib>
+#include <unistd.h>
 
 void usage () {
     std::cout << "Usage: edep-sim [options] [macros]" << std::endl;

--- a/display/CMakeLists.txt
+++ b/display/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CMAKE_VERBOSE_MAKEFILE TRUE)
 # Configure the dependencies
 find_package(ROOT REQUIRED
   COMPONENTS Geom Physics Matrix MathCore Tree RIO
-  Eve TreePlayer Ged RGL Gui Graf Graf3d) 
+  Eve TreePlayer Ged RGL Gui Graf Graf3d EG) 
 if(ROOT_FOUND)
   include(${ROOT_USE_FILE})
 endif(ROOT_FOUND)

--- a/src/EDepSimPhysicsList.cc
+++ b/src/EDepSimPhysicsList.cc
@@ -13,6 +13,8 @@
 #include <G4ParticleTypes.hh>
 #include <G4ParticleTable.hh>
 
+#include <G4UnitsTable.hh>
+
 #include <G4PhysListFactory.hh>
 
 #include <G4Gamma.hh>


### PR DESCRIPTION
These are required header files and a ROOT component which were needed to sort compiler errors on edep-sim running on my mac (geant 11.0.2/ ROOT 6.26/06)