### PR TITLE
G4.11.x type errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Makefile
 *_C.*
 *.pcm
 *.png
+*darwin*
+*.json

--- a/setup.sh
+++ b/setup.sh
@@ -82,9 +82,9 @@ ___path_prepend () {
     eval export $1="$2:\$$1"
 }
 ___path_remove ()  {
-    export $1=$(eval echo -n \$$1 | \
+    export $1="$(eval echo -n \$$1 | \
 	awk -v RS=: -v ORS=: '$0 != "'$2'"' | \
-	sed 's/:$//'); 
+	sed 's/:$//');"
 }
 
 ___path_prepend PATH ${EDEP_ROOT}/${EDEP_TARGET}/bin

--- a/src/EDepSimTrajectoryPoint.cc
+++ b/src/EDepSimTrajectoryPoint.cc
@@ -18,6 +18,12 @@
 
 G4Allocator<EDepSim::TrajectoryPoint> aTrajPointAllocator;
 
+const G4String getTextForEnum(int enumVal)
+{
+    return EnumStrings[enumVal];
+}
+
+
 EDepSim::TrajectoryPoint::TrajectoryPoint()
     : fTime(0.), fMomentum(0.,0.,0.),
       fStepStatus(fUndefined),
@@ -128,7 +134,7 @@ std::vector<G4AttValue>* EDepSim::TrajectoryPoint::CreateAttValues() const {
 
     values->push_back(G4AttValue("Momentum",
                                  G4BestUnit(fMomentum,"Momentum"),""));
-    values->push_back(G4AttValue("StepStatus",fStepStatus,""));
+    values->push_back(G4AttValue("StepStatus", getTextForEnum(fStepStatus), ""));
 
     values->push_back(G4AttValue("PhysVolName",fPhysVolName,""));
 

--- a/src/EDepSimTrajectoryPoint.hh
+++ b/src/EDepSimTrajectoryPoint.hh
@@ -92,6 +92,24 @@ public:
     G4ThreeVector fPrevPosition;
 };
 
+static const G4String EnumStrings[]{
+    "fWorldBoundary",
+    // Step reached the world boundary
+    "fGeomBoundary",
+    // Step defined by a geometry boundary
+    "fAtRestDoItProc",
+    // Step defined by a PreStepDoItVector
+    "fAlongStepDoItProc",
+    // Step defined by a AlongStepDoItVector
+    "fPostStepDoItProc",
+    // Step defined by a PostStepDoItVector
+    "fUserDefinedLimit",
+    // Step defined by the user Step limit in the logical volume
+    "fExclusivelyForcedProc",
+    // Step defined by an exclusively forced PostStepDoIt process
+    "fUndefined" // Step not defined yet
+};
+
 #if defined G4TRACKING_ALLOC_EXPORT
 extern G4DLLEXPORT G4Allocator<EDepSim::TrajectoryPoint> aTrajPointAllocator;
 #else

--- a/src/NESTVersion098/G4S1Light.cc
+++ b/src/NESTVersion098/G4S1Light.cc
@@ -136,7 +136,7 @@ G4S1Light::PostStepDoIt(const G4Track& aTrack, const G4Step& aStep)
         // scintillating material, and save Z for later L calculation, or
         // return if no valid scintillators are found on this step, which is
         // protection against G4Exception or seg. fault/violation
-        G4Element *ElementA = NULL, *ElementB = NULL;
+        const G4Element *ElementA = NULL, *ElementB = NULL;
         if (aMaterial && aMaterial->GetMaterialPropertiesTable()) {
           const G4ElementVector* theElementVector1 =
             aMaterial->GetElementVector();

--- a/src/NESTVersion098/G4S2Light.cc
+++ b/src/NESTVersion098/G4S2Light.cc
@@ -108,7 +108,7 @@ G4S2Light::PostStepDoIt(const G4Track& aTrack, const G4Step& aStep)
 	}
 	const G4ElementVector* theElementVector =
 	  aMaterial->GetElementVector();
-	G4Element* Element = (*theElementVector)[0]; G4int z1;
+	const G4Element* Element = (*theElementVector)[0]; G4int z1;
 	if ( Element ) z1 = (G4int)(Element->GetZ()); else z1 = -1;
 	G4double z_anode = BORDER + GASGAP;
 	G4double z_start = BORDER;
@@ -262,7 +262,7 @@ G4double G4S2Light::GetMeanFreePath(const G4Track& aTrack,
   const G4Material* aMaterial = aTrack.GetMaterial();
   if ( !aMaterial ) return DBL_MIN;
   const G4ElementVector* theElementVector = aMaterial->GetElementVector();
-  G4Element* Element = (*theElementVector)[0]; G4int z1;
+  const G4Element* Element = (*theElementVector)[0]; G4int z1;
   if ( Element ) z1 = (G4int)(Element->GetZ()); else z1 = -1;
   if ( (z1==2 || z1==10 || z1==18 || z1==36 || z1==54) &&
        aMaterial->GetState() == kStateLiquid ) {


### PR DESCRIPTION
G4AttValue demands a G4String and cannot convert the enum fStepStatus into one. Also a couple compiler errors fixed by adding const.