### PR TITLE
add subrun field to event header

### DIFF
--- a/io/TG4Event.h
+++ b/io/TG4Event.h
@@ -15,6 +15,9 @@ public:
     /// The run number
     int RunId;
     
+    /// The sub-run number
+    int SubrunId;
+    
     /// The event number
     int EventId;
 
@@ -38,6 +41,6 @@ public:
     /// map is keyed using the sensitive volume name.
     TG4HitSegmentDetectors SegmentDetectors;
 
-    ClassDef(TG4Event,1)
+    ClassDef(TG4Event,2)
 };
 #endif


### PR DESCRIPTION
Many (most?) event streams include a "sub-run" number to differentiate multiple data-taking periods ("subruns") within the same data-taking conditions ("runs").  This PR would add a field to the header to keep track of subrun number also.