### PR TITLE
Adding shapes necessary for 2x2 and beyond

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Makefile
 *_C.*
 *.pcm
 *.png
+*darwin*


### PR DESCRIPTION
In order to process the DUNE 2x2 geometry, toruses need to be added to edep-sim. I also added other shapes that looked useful for other geometry builds. 