### PR TITLE
Add dynamically linked physics lists

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,11 +1,29 @@
 Changes in 4.x.x
 
+* Users can dynamically load a G4VPhysicsConstructor to add extra
+  physics to the geant physics list.  This constructor will be
+  registered after G4OpticalPhysics, and before EDepSim::ExtraPhysics.
+  The constructor is specified in the EXTRAPHYSICS environment
+  variable as "EXTRA:library-path:symbol-name".  The symbol name
+  should specify a C function with the signature
+  `G4VModularPhysicsList* (*)(char*)`.  The "EXTRA" prefix is
+  required.
+
+* Users can dynamically load a G4VModularPhysics to override the GEANT
+  reference physics lists by setting the PHYSLIST environment variable
+  to "EXTERN:library-path:symbol-name".  The symbol name should
+  specify a C function with the signature `G4VModularPhysicsList*
+  (*)(char*)`.
+
 * Users can dynamically load run, event, tracking and stepping user
   actions that will be called as part of the equivalent EDepSim user
   actions.
 
 * Users can dynamically load a kinematics generator using the
   /edep/generator/external/ macro commands.
+
+* Fix: Add protection to the SurfaceSD for when the process pointer is
+  not available.
 
 Changes in 4.1.0
 

--- a/src/EDepSimPhysicsList.cc
+++ b/src/EDepSimPhysicsList.cc
@@ -3,6 +3,7 @@
 #include "EDepSimException.hh"
 #include "EDepSimExtraPhysics.hh"
 #include "EDepSimDokeBirksSaturation.hh"
+#include "EDepSimGetExternalActionConstructor.hh"
 
 #include <EDepSimLog.hh>
 
@@ -44,9 +45,11 @@ EDepSim::PhysicsList::PhysicsList(G4String physName)
 
     // Check to see if the physics list has set the environment variable
     // PHYSLIST
-    if (!phys) {
-        char* list = getenv("PHYSLIST");
-        if (list) {
+    char* list = getenv("PHYSLIST");
+    if (!phys and list) {
+        std::string listName(list);
+        phys = ExternalPhysicsList(listName);
+        if (!phys) {
             EDepSimLog("Set the physics list from the PHYSLIST environment: "
                        << list);
             phys = factory.ReferencePhysList();
@@ -86,6 +89,13 @@ EDepSim::PhysicsList::PhysicsList(G4String physName)
 
     // Add the optical physics so photons can be created.
     RegisterPhysics(new G4OpticalPhysics());
+
+    // Add an external extra physics list
+    char* extra = getenv("EXTRAPHYSICS");
+    if (extra) {
+        std::string extraPhysicsName(extra);
+        RegisterPhysics(ExternalExtraPhysics(extraPhysicsName));
+    }
 
     // Add our specific lists.
     fExtra = new EDepSim::ExtraPhysics();
@@ -140,4 +150,64 @@ void EDepSim::PhysicsList::SetCutForPositron(G4double cut) {
 
 void EDepSim::PhysicsList::SetIonizationModel(bool b) {
     fExtra->SetIonizationModel(b);
+}
+
+G4VModularPhysicsList*
+EDepSim::PhysicsList::ExternalPhysicsList(std::string externName) {
+    // Strip the EXTERN:
+    std::size_t pos = externName.find("EXTERN:");
+    if (pos == std::string::npos) return nullptr;
+
+    EDepSimLog("EXTERN NAME " << externName);
+
+    pos = externName.find(":");
+    std::string prefix = externName.substr(0,pos);
+    externName.erase(0,pos+1);
+
+    pos = externName.find(":");
+    std::string library = externName.substr(0,pos);
+    externName.erase(0,pos+1);
+
+    pos = externName.find(":");
+    std::string symbol = externName.substr(0,pos);
+
+    EDepSimLog("Use external physics list: "
+               << "G4VModularPhysicsList* "
+               << library << "::" << symbol << "(char*)");
+
+    G4VModularPhysicsList* phys
+        = EDepSim::CallExternalConstructor<G4VModularPhysicsList>(
+            library, symbol, "EDepSim");
+
+    if (!phys) EDepSimThrow("Library not opened");
+
+    return phys;
+}
+
+G4VPhysicsConstructor*
+EDepSim::PhysicsList::ExternalExtraPhysics(std::string externName) {
+    // Strip the prefix:
+
+    std::size_t pos = externName.find(":");
+    std::string prefix = externName.substr(0,pos);
+    externName.erase(0,pos+1);
+
+    pos = externName.find(":");
+    std::string library = externName.substr(0,pos);
+    externName.erase(0,pos+1);
+
+    pos = externName.find(":");
+    std::string symbol = externName.substr(0,pos);
+
+    EDepSimLog("Use external extra physics list: "
+               << "G4VPhysicsConstructor* "
+               << library << "::" << symbol << "(char*)");
+
+    G4VPhysicsConstructor* phys
+        = EDepSim::CallExternalConstructor<G4VPhysicsConstructor>(
+            library, symbol, "EDepSim");
+
+    if (!phys) EDepSimThrow("Library not opened");
+
+    return phys;
 }

--- a/src/EDepSimPhysicsList.hh
+++ b/src/EDepSimPhysicsList.hh
@@ -47,6 +47,15 @@ public:
 
 private:
 
+    /// Load a modular physics list from an external library.  The externName
+    /// parameter needs to be of the form "EXTERN:library-name:symbol-name"
+    G4VModularPhysicsList* ExternalPhysicsList(std::string externName);
+
+    /// Load an extra physics constructor from an external library.  The
+    /// externName parameter needs to be of the form
+    /// "EXTERN:library-name:symbol-name"
+    G4VPhysicsConstructor* ExternalExtraPhysics(std::string externName);
+
     /// The gamma-ray range cut.
     G4double fCutForGamma;
 


### PR DESCRIPTION
This adds an interface to let users dynamically link to externally defined physics lists.  This can add a G4VModularPhysicsList which will replace the main physics list.  This can also add a G4VPhysicsConstructor which can added extra physics to particles.
