### PR TITLE
Do not discard primary optical photons

### DIFF
--- a/src/EDepSimSurfaceSD.cc
+++ b/src/EDepSimSurfaceSD.cc
@@ -117,11 +117,6 @@ G4bool EDepSim::SurfaceSD::ProcessHits(G4Step* theStep,
         EDepSimTrace("   Volume: NONE");
     }
 
-    if (theProcess == nullptr) {
-        // No process here, so don't create this step.
-        return true;
-    }
-
     EDepSimDebug("Create Hit:"
                  << " [" << hitPosition.x()/mm
                  << ", " << hitPosition.y()/mm


### PR DESCRIPTION
Xuyang Ning pointed out that a check in SurfaceSD prevented tracking opticalphotons as a primary particle.  Fix that.  Closes #76