### PR TITLE
Remove statically define trajectory map

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sure that they can be located (using `thisroot.sh` and `geant4.sh`).
 
 The simulation is built using cmake.  CMake can be run by hand, but there
 is a script in the build directory that can be run using the `edep-build`
-alias.  The build has been tested with GEANT4 10.2 and ROOT 6.08, but it
+alias.  The build has been tested with GEANT4 11.4 and ROOT 6.36, but it
 will probably build with any recent version of GEANT4 and ROOT.
 
 If you have doxygen installed in a place where `cmake` can find it, then
@@ -73,10 +73,13 @@ GEANT4 and ROOT, but a few non-default options are needed:
 
  * Recommended GEANT4 Datafiles: "-DGEANT4_INSTALL_DATA=ON"
 
+ * If the display is being built, ROOT needs to be compiled with the
+   geometry library and opengl.
+ 
 These options are already turned on in most GEANT4 and ROOT installations.
 
 If you are compiling ROOT and GEANT4 by hand, following is a general sketch
-of how to install them (changed for your versions):
+of how to install them (change for your versions):
 
 ```bash
 tar xvzf root_v6.22.00.source.tar.gz
@@ -1228,3 +1231,13 @@ the second particle is adjusted to be relative to the position of the first
 example, if the optional third argument is true, the first vertex position
 is [1,1,1], and the second vertex position is [0,1,0], then the simulated
 vertex positions will be [1,1,1] and [1,2,1].
+
+## Dark History
+
+EDep-Sim started as a simulation, named `csim`, of a proposed
+water Cherenkov detector called the Underground Neutrino
+Observatory (UNO) in around 2000 using Geant4.3 (as best as can
+be deciphered from old CVS repositories).  The core routines
+later evolved to be used by the T2K near detector, were further
+changed to handle the CAPTAIN experiment, and finally separated
+from any particular experiment to become EDepSim.

--- a/src/EDepSimTrajectoryMap.cc
+++ b/src/EDepSimTrajectoryMap.cc
@@ -1,18 +1,18 @@
 #include "EDepSimTrajectoryMap.hh"
 #include "EDepSimTrajectory.hh"
 #include "EDepSimException.hh"
+#include "EDepSimUserEventInformation.hh"
 
 #include <G4VTrajectory.hh>
 #include <G4VTrajectoryPoint.hh>
 #include <G4ThreeVector.hh>
+#include <G4EventManager.hh>
 
 #include "EDepSimLog.hh"
 #include "EDepSimBacktrace.hh"
 
-std::map<int, G4VTrajectory*> EDepSim::TrajectoryMap::fMap;
-
 void EDepSim::TrajectoryMap::Clear() {
-    fMap.clear();
+    GetMap().clear();
 }
 
 void EDepSim::TrajectoryMap::Add(G4VTrajectory* traj) {
@@ -27,7 +27,7 @@ void EDepSim::TrajectoryMap::Add(G4VTrajectory* traj) {
     G4VTrajectory* oldTraj = EDepSim::TrajectoryMap::Get(trackId);
     if (oldTraj == nullptr) {
         // The trajectory doesn't exist, so add it
-        fMap[trackId] = update;
+        GetMap()[trackId] = update;
         return;
     }
     // Check that the new trajectory matches the old trajectory.  Shouldn't
@@ -74,9 +74,17 @@ int EDepSim::TrajectoryMap::FindPrimaryId(int trackId) {
 }
 
 G4VTrajectory* EDepSim::TrajectoryMap::Get(int trackId) {
-    std::map<int,G4VTrajectory*>::iterator t = fMap.find(trackId);
-    if (t == fMap.end()) {
+    std::map<int,G4VTrajectory*>::iterator t = GetMap().find(trackId);
+    if (t == GetMap().end()) {
         return NULL;
     }
     return t->second;
+}
+
+std::map<int,G4VTrajectory*>& EDepSim::TrajectoryMap::GetMap() {
+    EDepSim::UserEventInformation* userEventInfo
+        = dynamic_cast<EDepSim::UserEventInformation*>(
+            G4EventManager::GetEventManager()->GetUserInformation());
+    if (!userEventInfo) throw std::runtime_error("No user event info");
+    return userEventInfo->fMap;
 }

--- a/src/EDepSimTrajectoryMap.hh
+++ b/src/EDepSimTrajectoryMap.hh
@@ -8,9 +8,11 @@
 
 class G4VTrajectory;
 
-/// Maintain a singleton map of track Id to the trajectory in the trajectory
-/// container.  THIS IS NOT THREAD SAFE AND CAN NOT BE USED WITH MULTITHREAD
-/// GEANT4.
+/// Maintain a the track Id to the trajectory in the trajectory container for
+/// this event. This could be implemented directly using find and the
+/// G4TrajectoryContainer vector, but that seems like it's depending on an
+/// internal implementation detail.  Instead, this maintains a std::map
+/// between the integer trajectory id and the trajectory pointer.
 namespace EDepSim {class TrajectoryMap;}
 class EDepSim::TrajectoryMap {
 public:
@@ -31,11 +33,9 @@ public:
     static int FindPrimaryId(int trackId);
 
 private:
-    /// A map to the trajectories information indexed the the track id. Be
-    /// careful since the trajectory information is owned by the event, so if
-    /// you try to use this after a trajectory has been deleted... bad things
-    /// will happen.
-    static std::map<int,G4VTrajectory*> fMap;
+    /// Provide a getter for the map.  This could be setup to return a
+    /// lock_guard for RAII.  The returned object needs to act like the map.
+    static std::map<int,G4VTrajectory*>& GetMap();
 
     /// The constructor is private so that it can only be created using the
     /// static get method.

--- a/src/EDepSimUserEventInformation.hh
+++ b/src/EDepSimUserEventInformation.hh
@@ -6,13 +6,21 @@
 
 #include <G4VUserEventInformation.hh>
 #include <G4PrimaryVertex.hh>
+#include <G4VTrajectory.hh>
 
-namespace EDepSim {class UserEventInformation;}
+#include <map>
+
+namespace EDepSim {
+    class UserEventInformation;
+    class TrajectoryMap;
+}
 class EDepSim::UserEventInformation : public G4VUserEventInformation {
+    friend EDepSim::TrajectoryMap;
+
 public:
     UserEventInformation();
     virtual ~UserEventInformation();
-    
+
     /// Print information about the event.
     virtual void Print() const;
 
@@ -22,5 +30,13 @@ public:
     void InitializeEvent(void);
 
 private:
+
+    /// A map to the trajectories information indexed the the track id. Be
+    /// careful since the trajectory information is owned by the G4Event, so
+    /// if you try to use this after a trajectory has been deleted... bad
+    /// things will happen.  That should never happen since the
+    /// UserEventInformation is also owned by the event.  This is directly
+    /// access by TrajectoryMap (which is a friend).
+    std::map<int, G4VTrajectory*> fMap;
 };
 #endif


### PR DESCRIPTION
The trajectory id map was being saved in a singleton that persisted between events.  That's been fixed so that the map is now saved in the G4Event user event information.  This will work for multi-threading as long as G4 is used in an event-parallel mode (no locks are used for this is edep-sim).  The map access is isolated, so it could be adapted for finer thread granularity.

Note: This will not make EDepSim thread safe since the persistence manager isn't protected by locks.