### PR TITLE
Select tracks by interaction type

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,6 +6,7 @@ let me (clark.mcgrew@stonybrook.edu) know.
 
 C. Backhouse -- Compilation improvements
 A. Cudd      -- Arbitrary EM fields
+J. Elias     -- Suggested additional control for saving trajectories
 M. Kordosky  -- New geometry shapes
 M. Kramer    -- New geometry shapes
 C. McGrew    -- Has been working on this far to long

--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ geometry).
 
 The [GEANT4 output](./doc/OUTPUT.md) is made available by registering a
 user class derived from EDepSim::PersistencyManager (which will fully
-marshal the information). A default EDepSim::RootPersistencyManager is
-provided to save the event information to a ROOT tree, and provides the
-_usual_ method of accessing the results from the simulation. The classes in
-the ROOT tree are accessible through python, and in C++ using the
-edepsim_io library that is part of this distribution.
+marshal the information). Control over the type and amount of information
+saved is provided through the input macro file (see the `/edep/db/set/`
+commands). A default EDepSim::RootPersistencyManager is provided to save the
+event information to a ROOT tree, and provides the _usual_ method of
+accessing the results from the simulation. The classes in the ROOT tree are
+accessible through python, and in C++ using the edepsim_io library that is
+part of this distribution.
 
 Where it is available (and in particular for argon), the simulation
 implements a fairly detailed model of the energy deposited as ionization

--- a/doc/OUTPUT.md
+++ b/doc/OUTPUT.md
@@ -1,6 +1,54 @@
+## Controlling the output saved by EDepSim::PersistencyManager
+
+The EDepSim::PersistencyManager class summarizes the output of
+GEANT4 based on settings provided in the macro file with the
+`/edep/db/set` commands. All of the deposited energy, and photons
+will be saved, so most of the settings control how much trajectory
+information is available in the output file.
+
+Control over saving a trajectory is provided by the `saveAllTraj`,
+`saveAllPrimTraj`, `savePhotonTraj`, `lengthThreshold`,
+`neutronThreshold`, and `gammaThreshold` commands.  These commands
+set a momentum threshold for when each category of trajectory
+should be saved. Additional control for saving trajectories is
+provided by the `trajectoryRule` command (see below).
+
+Control over which trajectory points are saved is provided by the
+`trajectoryAccuracy`, `trajectoryDeposit`, and
+`trajectoryBoundary` commands. The `trajectoryAccuracy` command
+makes sure that the straight line between two saved trajectory
+points stays within the requested distance to the true trajectory.
+The `trajectoryDeposit` command will force trajectory points with
+more than the requested deposit to be saved. The
+`trajectoryBoundary` command controls if a point will be saved as
+a particle enters or leaves a volume.  It takes a Perl RegExp that
+is compared against a string formated as
+`:particle-name:charge:volume-name:` where the particle name is
+one of the standard GEANT4 particle names, the charge is either
+`charged` or `neutral`, and the volume is the physical volume name
+as known to GEANT4.
+
+Trajectories and trajectory points associated with particular
+interactions can be saved using the `trajectoryRule` command which
+accepts a process type and sub-type, and minimum deposit (or
+momentum), and a category.  The process types are integer values
+defined in the `G4ProcessType.h` file distributed with GEANT4 (a
+value of -1 will accept all process types). The subtypes are
+integer values defined by the particular interaction models, the
+notable values can be found in `G4EmProcessSubType.hh`,
+`G4OpProcessSubType.hh`, and `G4HadronicProcessType.hh` (a value
+of -1 will accept all process sub-types).  The `category` controls
+whether the rule applies to just trajectories, just trajectory
+points, or both.
+
 ## Accessing the output with EDepSim::PersistencyManager
 
-After an GEANT4 event is processed, the event is summarized using the EDepSim::PersistencyManager class which is a base class that users can specialize for their specific purposes.  The PersistencyManager class will marshal summaries of the event into local classes and provides the main access to the event.  By default, the output is written to a ROOT file with classes described by the `edepsim_io` library (see below).
+After an GEANT4 event is processed, the event is summarized using the
+EDepSim::PersistencyManager class which is a base class that users can
+specialize for their specific purposes.  The PersistencyManager class will
+marshal summaries of the event into local classes and provides the main
+access to the event.  By default, the output is written to a ROOT file with
+classes described by the `edepsim_io` library (see below).
 
 ### Reading the output produced by EDepSim::RootPersistencyManager.
 

--- a/doc/edepsim-command.list
+++ b/doc/edepsim-command.list
@@ -4775,9 +4775,9 @@ Set various parameters
    trajectoryDeposit * Set the minimum energy deposit for a trajectory point.
    trajectoryBoundary * Add a Perl RegExp for a phys. vol. boundary where a trajectory point is saved. The expression is compared to a string constructed ":particle:charge:volume:" where particle is the particle name, charge is "charged" or "neutral" and volume is the physical volume name.
    clearBoundaries * Remove all of the boundaries for trajectory points.
-   trajectoryRule * Add a rule to save a trajectory point.
+   trajectoryRule * Add a rule to save a trajectory or trajectory point.
    clearTrajectoryRules * Clear all of the trajectory point save rules.
-   savePhotonTraj * ...Title not available...
+   savePhotonTraj * Control if photon trajectories are placed into the trajectory stack so tracking is a little faster and uses less resources. True: Photon trajectories will be saved for vanilla optical photon tracking. False: Photon trajectories are not created.
 
 
 Command /edep/db/set/gammaThreshold
@@ -4828,7 +4828,6 @@ Parameter : Unit
 Command /edep/db/set/saveAllPrimTraj
 Guidance :
 Control which primaries have saved trajectories -- True: Save all prim. part. trajectories. False: Save prim. that ultimately deposit energy in SD.
-Control if photon trajectories are placed into the trajectory stack so tracking is a little faster and uses less resources. True: Photon trajectories will be saved for vanilla optical photon tracking. False: Photon trajectories are not created.
 
 Parameter : 
  Parameter type  : b
@@ -4900,7 +4899,7 @@ Remove all of the boundaries for trajectory points.
 
 Command /edep/db/set/trajectoryRule
 Guidance :
-Add a rule to save a trajectory point.
+Add a rule to save a trajectory or trajectory point.
 
 Parameter : process
 Select trajectory points with this process. The process numbers are defined by geant in G4ProcessType.h. A value of -1 specifies all processes.
@@ -4924,6 +4923,13 @@ Parameter : energy unit
  Omittable       : True
  Default value   : MeV
 
+Parameter : category
+What to apply the rule to (trajectories, or points). If the rule applies to trajectories, it will also be applied to trajectory points.
+ Parameter type  : s
+ Omittable       : True
+ Default value   : point
+ Candidates      : all point trajectory
+
 
 
 Command /edep/db/set/clearTrajectoryRules
@@ -4934,6 +4940,7 @@ Clear all of the trajectory point save rules.
 
 Command /edep/db/set/savePhotonTraj
 Guidance :
+Control if photon trajectories are placed into the trajectory stack so tracking is a little faster and uses less resources. True: Photon trajectories will be saved for vanilla optical photon tracking. False: Photon trajectories are not created.
 
 Parameter : 
  Parameter type  : b

--- a/doc/html/_edep_db_set_.html
+++ b/doc/html/_edep_db_set_.html
@@ -55,7 +55,6 @@ Set length of track in an SD for writing out particle trajectories<br>
 <h3 id="c3">saveAllPrimTraj [<i></i>]</h3>
 <p>
 Control which primaries have saved trajectories -- True: Save all prim. part. trajectories. False: Save prim. that ultimately deposit energy in SD.<br>
-Control if photon trajectories are placed into the trajectory stack so tracking is a little faster and uses less resources. True: Photon trajectories will be saved for vanilla optical photon tracking. False: Photon trajectories are not created.<br>
 <p>Available at all Geant4 states.
 <p>Parameters<table border=1>
 <tr><td>
@@ -108,9 +107,9 @@ Idle
 <p>
 Remove all of the boundaries for trajectory points.<br>
 <p>Available at all Geant4 states.
-<h3 id="c9">trajectoryRule [<i>process</i>] [<i>subprocess</i>] [<i>threshold</i>] [<i>energy unit</i>]</h3>
+<h3 id="c9">trajectoryRule [<i>process</i>] [<i>subprocess</i>] [<i>threshold</i>] [<i>energy unit</i>] [<i>category</i>]</h3>
 <p>
-Add a rule to save a trajectory point.<br>
+Add a rule to save a trajectory or trajectory point.<br>
 <p>Available Geant4 state(s) : PreInit 
 Idle 
 <p>Parameters<table border=1>
@@ -125,13 +124,18 @@ Idle
 <td><tr><td>energy unit
 <td>type s
 <td>Omittable : default value = MeV
-<td></table>
+<td><tr><td>category
+<td>type s
+<td>Omittable : default value = point
+<td>Parameter candidates : all point trajectory
+</table>
 <h3 id="c10">clearTrajectoryRules</h3>
 <p>
 Clear all of the trajectory point save rules.<br>
 <p>Available at all Geant4 states.
 <h3 id="c11">savePhotonTraj [<i></i>]</h3>
 <p>
+Control if photon trajectories are placed into the trajectory stack so tracking is a little faster and uses less resources. True: Photon trajectories will be saved for vanilla optical photon tracking. False: Photon trajectories are not created.<br>
 <p>Available at all Geant4 states.
 <p>Parameters<table border=1>
 <tr><td>

--- a/src/EDepSimPersistencyManager.cc
+++ b/src/EDepSimPersistencyManager.cc
@@ -117,6 +117,28 @@ void EDepSim::PersistencyManager::AddTrajectoryPointRule(int process,
         TrajectoryPointRule(process,subprocess,threshold));
 }
 
+bool EDepSim::PersistencyManager::MatchesTrajectoryRule(int process,
+                                                        int subprocess,
+                                                        double enr,
+                                                        int category) {
+    for (const TrajectoryPointRule& rule : fTrajectoryPointRules) {
+        if (enr < rule.fThreshold) {
+            continue;
+        }
+        if (rule.fProcess >= 0 and process != rule.fProcess) {
+            continue;
+        }
+        if (rule.fSubprocess >= 0 and subprocess != rule.fSubprocess) {
+            continue;
+        }
+        if (rule.fCategory >= 0 and (category & rule.fCategory) == 0) {
+            continue;
+        }
+        return true;
+    }
+    return false;
+}
+
 bool EDepSim::PersistencyManager::SaveTrajectoryBoundary(G4VTrajectory* g4Traj,
                                                     G4StepStatus status,
                                                     G4String currentVolume,

--- a/src/EDepSimPersistencyManager.cc
+++ b/src/EDepSimPersistencyManager.cc
@@ -180,7 +180,9 @@ void EDepSim::PersistencyManager::UpdateSummaries(const G4Event* event) {
     EDepSimLog("Event Summary for run " << fEventSummary.RunId
                << " event " << fEventSummary.EventId);
 
-    // Summarize the trajectories first so that fTrackIdMap is filled.
+    // Summarize the trajectories first. This goes through the
+    // EDepSim::TrajectoryContainer and marks the trajectory objects that
+    // should be saved.
     MarkTrajectories(event);
 
     SummarizePrimaries(fEventSummary.Primaries,event->GetPrimaryVertex());
@@ -268,7 +270,9 @@ void EDepSim::PersistencyManager::SummarizeTrajectories(
     TG4TrajectoryContainer& dest,
     const G4Event* event) {
     dest.clear();
-    MarkTrajectories(event);
+
+    // The trajectories that should be saved must have already been marked
+    // using MarkTrajectories()
 
     // Build a map of the original G4 TrackID to the new relocated TrackId
     // (note capitalization).  This also uses the fact that maps are sorted as
@@ -388,6 +392,9 @@ void EDepSim::PersistencyManager::MarkTrajectories(const G4Event* event) {
     //       1) a daughter deposited energy in a sensitive detector
     //       2) or, SaveAllPrimaryTrajectories() is true
     //
+    //   ** Trajectories that the user has explicitly requested by
+    //         setting a /edep/db/set/trajectoryRule
+    //
     //   ** Trajectories created by a particle decay if
     //       1) a daughter deposited energy in a sensitve detector
     //       2) or, SaveAllPrimaryTrajectories() is true.
@@ -408,6 +415,8 @@ void EDepSim::PersistencyManager::MarkTrajectories(const G4Event* event) {
         }
         std::string particleName = ndTraj->GetParticleName();
         std::string processName = ndTraj->GetProcessName();
+        int processType = ndTraj->GetProcessType();
+        int processSubtype = ndTraj->GetProcessSubType();
         double initialMomentum = ndTraj->GetInitialMomentum().mag();
 
         // Check if all primary particle trajectories should be saved.  The
@@ -421,6 +430,17 @@ void EDepSim::PersistencyManager::MarkTrajectories(const G4Event* event) {
                 ndTraj->MarkTrajectory();
                 continue;
             }
+        }
+
+        // Check if the user as explicitly asked for this trajectory by
+        // setting a value for the /edep/db/set/trajectoryRule macro command.
+        // The argument "1" flags that this is checking for a trajectory, and
+        // not a trajectory point.
+        if (MatchesTrajectoryRule(processType, processSubtype,
+                                  initialMomentum, 1)) {
+            // Save this trajectory, and it's immediate parent.
+            ndTraj->MarkTrajectory(1);
+            continue;
         }
 
         // Check if everything should be saved.
@@ -451,8 +471,9 @@ void EDepSim::PersistencyManager::MarkTrajectories(const G4Event* event) {
         }
 
         // Save particles that produce charged track inside a sensitive
-        // detector.  This doesn't automatically save, but the parents will be
-        // automatically considered for saving by the next bit of code.
+        // detector.  This doesn't automatically save the parents, but the
+        // parents will be automatically considered for saving by the next bit
+        // of code.
         if (ndTraj->GetSDLength() > GetLengthThreshold()) {
             ndTraj->MarkTrajectory(0);
             continue;

--- a/src/EDepSimPersistencyManager.cc
+++ b/src/EDepSimPersistencyManager.cc
@@ -112,9 +112,14 @@ void EDepSim::PersistencyManager::ClearTrajectoryBoundaries() {
 
 void EDepSim::PersistencyManager::AddTrajectoryPointRule(int process,
                                                          int subprocess,
-                                                         double threshold) {
+                                                         double threshold,
+                                                         int category) {
+    if (category == 0) {
+        EDepSimError("Trajectory rule applies to nothing... skipped");
+        return;
+    }
     fTrajectoryPointRules.emplace_back(
-        TrajectoryPointRule(process,subprocess,threshold));
+        TrajectoryPointRule(process,subprocess,threshold,category));
 }
 
 bool EDepSim::PersistencyManager::MatchesTrajectoryRule(int process,

--- a/src/EDepSimPersistencyManager.cc
+++ b/src/EDepSimPersistencyManager.cc
@@ -46,13 +46,13 @@
 // then it will create a simple tree that can be analyzed using root.  The
 // best way to access the tree is with the root interface to python (no
 // headers needed), or by using ROOT TFile::MakeProject.
-EDepSim::PersistencyManager::PersistencyManager()
-    : G4VPersistencyManager(), fFilename("/dev/null"),
-      fLengthThreshold(10*mm),
-      fGammaThreshold(5*MeV), fNeutronThreshold(50*MeV),
-      fTrajectoryPointAccuracy(1.*mm), fTrajectoryPointDeposit(0*MeV),
-      fSaveAllPrimaryTrajectories(true),
-      fSaveAllTrajectories(std::nan("not-set")) {
+EDepSim::PersistencyManager::PersistencyManager():
+    G4VPersistencyManager(), fFilename("/dev/null"),
+    fLengthThreshold(10*mm),
+    fGammaThreshold(5*MeV), fNeutronThreshold(50*MeV),
+    fTrajectoryPointAccuracy(1.*mm), fTrajectoryPointDeposit(0*MeV),
+    fSaveAllPrimaryTrajectories(true),
+    fSaveAllTrajectories(std::nan("not-set")) {
     fPersistencyMessenger = new EDepSim::PersistencyMessenger(this);
 }
 
@@ -84,7 +84,7 @@ G4bool EDepSim::PersistencyManager::Store(const G4Event* anEvent) {
 G4bool EDepSim::PersistencyManager::Store(const G4Run* aRun) {
     if (!aRun) return false;
     EDepSimSevere(" -- Run store called without a save method for "
-               << "GEANT4 run " << aRun->GetRunID());
+                  << "GEANT4 run " << aRun->GetRunID());
     return false;
 }
 
@@ -92,7 +92,7 @@ G4bool EDepSim::PersistencyManager::Store(const G4Run* aRun) {
 G4bool EDepSim::PersistencyManager::Store(const G4VPhysicalVolume* aWorld) {
     if (!aWorld) return false;
     EDepSimSevere(" -- Geometry store called without a save method for "
-               << aWorld->GetName());
+                  << aWorld->GetName());
     return false;
 }
 
@@ -110,23 +110,23 @@ void EDepSim::PersistencyManager::ClearTrajectoryBoundaries() {
     fTrajectoryBoundaries.clear();
 }
 
-void EDepSim::PersistencyManager::AddTrajectoryPointRule(int process,
-                                                         int subprocess,
-                                                         double threshold,
-                                                         int category) {
+void EDepSim::PersistencyManager::AddTrajectoryRule(int process,
+                                                    int subprocess,
+                                                    double threshold,
+                                                    int category) {
     if (category == 0) {
         EDepSimError("Trajectory rule applies to nothing... skipped");
         return;
     }
-    fTrajectoryPointRules.emplace_back(
-        TrajectoryPointRule(process,subprocess,threshold,category));
+    fTrajectoryRules.emplace_back(
+        TrajectoryRule(process,subprocess,threshold,category));
 }
 
 bool EDepSim::PersistencyManager::MatchesTrajectoryRule(int process,
                                                         int subprocess,
                                                         double enr,
                                                         int category) {
-    for (const TrajectoryPointRule& rule : fTrajectoryPointRules) {
+    for (const TrajectoryRule& rule : fTrajectoryRules) {
         if (enr < rule.fThreshold) {
             continue;
         }
@@ -145,9 +145,9 @@ bool EDepSim::PersistencyManager::MatchesTrajectoryRule(int process,
 }
 
 bool EDepSim::PersistencyManager::SaveTrajectoryBoundary(G4VTrajectory* g4Traj,
-                                                    G4StepStatus status,
-                                                    G4String currentVolume,
-                                                    G4String prevVolume) {
+                                                         G4StepStatus status,
+                                                         G4String currentVolume,
+                                                         G4String prevVolume) {
     if (status != fGeomBoundary) return false;
     std::string particleInfo = ":" + g4Traj->GetParticleName();
     if (std::abs(g4Traj->GetCharge())<0.1) particleInfo += ":neutral";
@@ -313,8 +313,8 @@ void EDepSim::PersistencyManager::SummarizeTrajectories(
                 ndTraj->GetParticleName());
         if (!part) {
             EDepSimError(std::string("EDepSim::RootPersistencyManager::")
-                      + "No particle information for "
-                      + ndTraj->GetParticleName());
+                         + "No particle information for "
+                         + ndTraj->GetParticleName());
         }
 
         fTrackIdMap[ndTraj->GetTrackID()] = index++;
@@ -573,7 +573,7 @@ void EDepSim::PersistencyManager::MarkTrajectories(const G4Event* event) {
 }
 
 void EDepSim::PersistencyManager::CopyTrajectoryPoints(TG4Trajectory& traj,
-                                                  G4VTrajectory* g4Traj) {
+                                                       G4VTrajectory* g4Traj) {
     std::vector<int> selected;
 
     // Choose the trajectory points that are going to be saved.
@@ -717,9 +717,9 @@ EDepSim::PersistencyManager::SummarizeHitSegments(const G4Event* event,
                           g4HitSeg->GetStart().z(),
                           g4HitSeg->GetStart().t());
         hit.Stop.SetXYZT(g4HitSeg->GetStop().x(),
-                          g4HitSeg->GetStop().y(),
-                          g4HitSeg->GetStop().z(),
-                          g4HitSeg->GetStop().t());
+                         g4HitSeg->GetStop().y(),
+                         g4HitSeg->GetStop().z(),
+                         g4HitSeg->GetStop().t());
         dest.push_back(hit);
     }
 }
@@ -750,7 +750,7 @@ void EDepSim::PersistencyManager::CopyHitContributors(
         TrackIdMap::iterator t = fTrackIdMap.find(ndTraj->GetTrackID());
         if (t == fTrackIdMap.end()) {
             EDepSimThrow("Contributor with unknown trajectory: "
-                      << ndTraj->GetTrackID());
+                         << ndTraj->GetTrackID());
         }
         dest.push_back(t->second);
     }
@@ -783,7 +783,7 @@ double EDepSim::PersistencyManager::FindTrajectoryAccuracy(
 }
 
 int EDepSim::PersistencyManager::SplitTrajectory(G4VTrajectory* g4Traj,
-                                            int point1, int point2) {
+                                                 int point1, int point2) {
 
     int point3 = 0.5*(point1 + point2);
     if (point3 <= point1) EDepSimThrow("Points too close to split");

--- a/src/EDepSimPersistencyManager.cc
+++ b/src/EDepSimPersistencyManager.cc
@@ -886,18 +886,10 @@ EDepSim::PersistencyManager::SelectTrajectoryPoints(std::vector<int>& selected,
         // Apply the trajectory point rules first to see if the user has asked
         // for this specific point.  A point might be selected multiple times,
         // but that's OK because duplicates will be rejected later.
-        for (const TrajectoryPointRule& rule : fTrajectoryPointRules) {
-            if (edepPoint->GetProcessDeposit() < rule.fThreshold) {
-                continue;
-            }
-            if (rule.fProcess >= 0
-                and edepPoint->GetProcessType() != rule.fProcess) {
-                continue;
-            }
-            if (rule.fSubprocess >= 0
-                and edepPoint->GetProcessSubType() != rule.fSubprocess) {
-                continue;
-            }
+        if (MatchesTrajectoryRule(edepPoint->GetProcessType(),
+                                  edepPoint->GetProcessSubType(),
+                                  edepPoint->GetProcessDeposit(),
+                                  2)) {
             selected.push_back(tp);
         }
         // Don't save pure navigation....

--- a/src/EDepSimPersistencyManager.hh
+++ b/src/EDepSimPersistencyManager.hh
@@ -203,7 +203,7 @@ public:
     /// point to be saved.
     virtual void ClearTrajectoryBoundaries();
 
-    /// Add a rule to save trajectory points.  The process type values are
+    /// Add a rule to save trajectory points. The process type values are
     /// defined in G4ProcessType.hh, and the subtype values are defined in
     /// several include files (particularly G4HadronicProcessType.hh, and
     /// G4EmProcessSubType.hh).  A value of -1 for either process or
@@ -216,6 +216,12 @@ public:
     virtual void ClearTrajectoryPointRules() {
         fTrajectoryPointRules.clear();
     }
+
+    /// Check to see if a particular process, subprocess, energy deposition
+    /// (or kinetic energy), plus category (1 for trajectory, 2 for trajectory
+    /// point, -1 for any) to be selected by a trajectory rule.
+    virtual bool MatchesTrajectoryRule(int process, int subprocess,
+                                       double enr, int category);
 
     /// Set the detector mask.
     void SetDetectorPartition(int partition) {fDetectorPartition = partition;}
@@ -367,6 +373,10 @@ private:
         /// The minimum deposited energy to save a trajectory point.  A
         /// negative value removes the threshold.
         double fThreshold;
+        /// Categories to select (-1 all, 1: trajectories, 2: trajectory
+        /// points).  This is a bit mask, so "3" will select both trajectories
+        /// and trajectory points.
+        int fCategory;
     };
     std::vector<TrajectoryPointRule> fTrajectoryPointRules;
 

--- a/src/EDepSimPersistencyManager.hh
+++ b/src/EDepSimPersistencyManager.hh
@@ -210,7 +210,8 @@ public:
     /// subprocess will match everything.
     virtual void AddTrajectoryPointRule(int process,
                                         int subprocess,
-                                        double threshold);
+                                        double threshold,
+                                        int category);
 
     /// Clear the rulees for trajectory points.
     virtual void ClearTrajectoryPointRules() {
@@ -362,8 +363,8 @@ private:
     /// An internal class to keep the rules used to save trajectory points.
     class TrajectoryPointRule {
     public:
-        TrajectoryPointRule(int p, int s, double t)
-            : fProcess(p), fSubprocess(s), fThreshold(t), fCategory(-1) {}
+        TrajectoryPointRule(int p, int s, double t, int c)
+            : fProcess(p), fSubprocess(s), fThreshold(t), fCategory(c) {}
         /// A process to be saved, or negative if all processes should be
         /// saved.
         int fProcess;

--- a/src/EDepSimPersistencyManager.hh
+++ b/src/EDepSimPersistencyManager.hh
@@ -208,14 +208,14 @@ public:
     /// several include files (particularly G4HadronicProcessType.hh, and
     /// G4EmProcessSubType.hh).  A value of -1 for either process or
     /// subprocess will match everything.
-    virtual void AddTrajectoryPointRule(int process,
-                                        int subprocess,
-                                        double threshold,
-                                        int category);
+    virtual void AddTrajectoryRule(int process,
+                                   int subprocess,
+                                   double threshold,
+                                   int category);
 
     /// Clear the rulees for trajectory points.
-    virtual void ClearTrajectoryPointRules() {
-        fTrajectoryPointRules.clear();
+    virtual void ClearTrajectoryRules() {
+        fTrajectoryRules.clear();
     }
 
     /// Check to see if a particular process, subprocess, energy deposition
@@ -361,9 +361,9 @@ private:
     std::vector<TPRegexp*> fTrajectoryBoundaries;
 
     /// An internal class to keep the rules used to save trajectory points.
-    class TrajectoryPointRule {
+    class TrajectoryRule {
     public:
-        TrajectoryPointRule(int p, int s, double t, int c)
+        TrajectoryRule(int p, int s, double t, int c)
             : fProcess(p), fSubprocess(s), fThreshold(t), fCategory(c) {}
         /// A process to be saved, or negative if all processes should be
         /// saved.
@@ -379,7 +379,7 @@ private:
         /// and trajectory points.
         int fCategory;
     };
-    std::vector<TrajectoryPointRule> fTrajectoryPointRules;
+    std::vector<TrajectoryRule> fTrajectoryRules;
 
     /// The detector partition
     int fDetectorPartition;

--- a/src/EDepSimPersistencyManager.hh
+++ b/src/EDepSimPersistencyManager.hh
@@ -363,7 +363,7 @@ private:
     class TrajectoryPointRule {
     public:
         TrajectoryPointRule(int p, int s, double t)
-            : fProcess(p), fSubprocess(s), fThreshold(t) {}
+            : fProcess(p), fSubprocess(s), fThreshold(t), fCategory(-1) {}
         /// A process to be saved, or negative if all processes should be
         /// saved.
         int fProcess;

--- a/src/EDepSimPersistencyMessenger.cc
+++ b/src/EDepSimPersistencyMessenger.cc
@@ -17,8 +17,8 @@
 #include <G4RunManager.hh>
 
 EDepSim::PersistencyMessenger::PersistencyMessenger(
-    EDepSim::PersistencyManager* persistencyMgr)
-    : fPersistencyManager(persistencyMgr) {
+    EDepSim::PersistencyManager* persistencyMgr):
+    fPersistencyManager(persistencyMgr) {
     fPersistencyDIR = new G4UIdirectory("/edep/db/");
     fPersistencyDIR->SetGuidance("Output file control commands.");
 
@@ -102,11 +102,11 @@ EDepSim::PersistencyMessenger::PersistencyMessenger(
     fClearBoundariesCMD->SetGuidance("Remove all of the boundaries for"
                                      " trajectory points.");
 
-    fTrajectoryPointRuleCMD
+    fTrajectoryRuleCMD
         = new G4UIcommand("/edep/db/set/trajectoryRule",this);
-    fTrajectoryPointRuleCMD->SetGuidance(
+    fTrajectoryRuleCMD->SetGuidance(
         "Add a rule to save a trajectory or trajectory point.");
-    fTrajectoryPointRuleCMD->AvailableForStates(
+    fTrajectoryRuleCMD->AvailableForStates(
         G4State_PreInit,G4State_Idle);
     G4UIparameter* param = new G4UIparameter("process",'i',false);
     param->SetGuidance(
@@ -114,7 +114,7 @@ EDepSim::PersistencyMessenger::PersistencyMessenger(
         " The process numbers are defined by geant"
         " in G4ProcessType.h."
         " A value of -1 specifies all processes.");
-    fTrajectoryPointRuleCMD->SetParameter(param);
+    fTrajectoryRuleCMD->SetParameter(param);
     param = new G4UIparameter("subprocess",'i',true);
     param->SetGuidance(
         "Select points with this subprocess."
@@ -125,25 +125,25 @@ EDepSim::PersistencyMessenger::PersistencyMessenger(
         " and G4HadronicProcessType.hh."
         " A value of -1 specifies all subprocesses.");
     param->SetDefaultValue(-1);
-    fTrajectoryPointRuleCMD->SetParameter(param);
+    fTrajectoryRuleCMD->SetParameter(param);
     param = new G4UIparameter("threshold",'d',true);
     param->SetGuidance("Select points with more than this energy deposit.");
     param->SetDefaultValue(-1.0);
-    fTrajectoryPointRuleCMD->SetParameter(param);
+    fTrajectoryRuleCMD->SetParameter(param);
     param = new G4UIparameter("energy unit",'s',true);
     param->SetDefaultValue("MeV");
-    fTrajectoryPointRuleCMD->SetParameter(param);
+    fTrajectoryRuleCMD->SetParameter(param);
     param = new G4UIparameter("category",'s',true);
     param->SetGuidance("What to apply the rule to (trajectories, or points)."
                        " If the rule applies to trajectories, it will also be"
                        " applied to trajectory points.");
     param->SetParameterCandidates("all point trajectory");
     param->SetDefaultValue("point");
-    fTrajectoryPointRuleCMD->SetParameter(param);
+    fTrajectoryRuleCMD->SetParameter(param);
 
-    fClearTrajectoryPointRulesCMD
+    fClearTrajectoryRulesCMD
         = new G4UIcmdWithoutParameter("/edep/db/set/clearTrajectoryRules",this);
-    fClearTrajectoryPointRulesCMD->SetGuidance(
+    fClearTrajectoryRulesCMD->SetGuidance(
         "Clear all of the trajectory point"
         " save rules.");
 
@@ -169,8 +169,8 @@ EDepSim::PersistencyMessenger::~PersistencyMessenger() {
     delete fTrajectoryPointDepositCMD;
     delete fTrajectoryBoundaryCMD;
     delete fClearBoundariesCMD;
-    delete fTrajectoryPointRuleCMD;
-    delete fClearTrajectoryPointRulesCMD;
+    delete fTrajectoryRuleCMD;
+    delete fClearTrajectoryRulesCMD;
     delete fPersistencyDIR;
     delete fPersistencySetDIR;
     delete fSavePhotonTrajectoriesCMD;
@@ -178,7 +178,7 @@ EDepSim::PersistencyMessenger::~PersistencyMessenger() {
 
 
 void EDepSim::PersistencyMessenger::SetNewValue(G4UIcommand* command,
-                                            G4String newValue) {
+                                                G4String newValue) {
     if (command==fOpenCMD) {
         fPersistencyManager->Open(newValue);
     }
@@ -219,7 +219,7 @@ void EDepSim::PersistencyMessenger::SetNewValue(G4UIcommand* command,
     else if (command == fClearBoundariesCMD) {
         fPersistencyManager->ClearTrajectoryBoundaries();
     }
-    else if (command == fTrajectoryPointRuleCMD) {
+    else if (command == fTrajectoryRuleCMD) {
         int process;
         int subprocess;
         double threshold;
@@ -235,13 +235,13 @@ void EDepSim::PersistencyMessenger::SetNewValue(G4UIcommand* command,
         if (categoryName == "all") category = -1;
         else if (categoryName == "trajectory") category = 1;
         else if (categoryName == "point") category = 2;
-        fPersistencyManager->AddTrajectoryPointRule(
+        fPersistencyManager->AddTrajectoryRule(
             process,subprocess,
             threshold*G4UIcommand::ValueOf(unit.c_str()),
             category);
     }
-    else if (command == fClearTrajectoryPointRulesCMD) {
-        fPersistencyManager->ClearTrajectoryPointRules();
+    else if (command == fClearTrajectoryRulesCMD) {
+        fPersistencyManager->ClearTrajectoryRules();
     }
     else if (command == fSavePhotonTrajectoriesCMD) {
         bool save = fSavePhotonTrajectoriesCMD->GetNewBoolValue(newValue);

--- a/src/EDepSimPersistencyMessenger.cc
+++ b/src/EDepSimPersistencyMessenger.cc
@@ -4,6 +4,7 @@
 #include "EDepSimPersistencyMessenger.hh"
 #include "EDepSimPersistencyManager.hh"
 #include "EDepSimUserTrackingAction.hh"
+#include "EDepSimLog.hh"
 
 #include <G4UIdirectory.hh>
 #include <G4UIcmdWithAString.hh>
@@ -104,7 +105,7 @@ EDepSim::PersistencyMessenger::PersistencyMessenger(
     fTrajectoryPointRuleCMD
         = new G4UIcommand("/edep/db/set/trajectoryRule",this);
     fTrajectoryPointRuleCMD->SetGuidance(
-        "Add a rule to save a trajectory point.");
+        "Add a rule to save a trajectory or trajectory point.");
     fTrajectoryPointRuleCMD->AvailableForStates(
         G4State_PreInit,G4State_Idle);
     G4UIparameter* param = new G4UIparameter("process",'i',false);
@@ -132,6 +133,13 @@ EDepSim::PersistencyMessenger::PersistencyMessenger(
     param = new G4UIparameter("energy unit",'s',true);
     param->SetDefaultValue("MeV");
     fTrajectoryPointRuleCMD->SetParameter(param);
+    param = new G4UIparameter("category",'s',true);
+    param->SetGuidance("What to apply the rule to (trajectories, or points)."
+                       " If the rule applies to trajectories, it will also be"
+                       " applied to trajectory points.");
+    param->SetParameterCandidates("all point trajectory");
+    param->SetDefaultValue("point");
+    fTrajectoryPointRuleCMD->SetParameter(param);
 
     fClearTrajectoryPointRulesCMD
         = new G4UIcmdWithoutParameter("/edep/db/set/clearTrajectoryRules",this);
@@ -141,7 +149,7 @@ EDepSim::PersistencyMessenger::PersistencyMessenger(
 
     fSavePhotonTrajectoriesCMD
         = new G4UIcmdWithABool("/edep/db/set/savePhotonTraj", this);
-    fSaveAllPrimaryTrajectoriesCMD->SetGuidance(
+    fSavePhotonTrajectoriesCMD->SetGuidance(
         "Control if photon trajectories are placed into the trajectory stack"
         " so tracking is a little faster and uses less resources."
         " True: Photon trajectories will be saved"
@@ -216,10 +224,21 @@ void EDepSim::PersistencyMessenger::SetNewValue(G4UIcommand* command,
         int subprocess;
         double threshold;
         std::string unit;
+        std::string categoryName;
+        int category = 0;
         std::istringstream val(newValue);
-        val >> process >> subprocess >> threshold >> unit;
+        val >> process >> subprocess >> threshold >> unit >> categoryName;
+        EDepSimLog("Trajectory Rule: "
+                   << " Process: " << process << "/" << subprocess
+                   << " Energy: " << threshold << " " << unit
+                   << " Category: " << categoryName);
+        if (categoryName == "all") category = -1;
+        else if (categoryName == "trajectory") category = 1;
+        else if (categoryName == "point") category = 2;
         fPersistencyManager->AddTrajectoryPointRule(
-            process,subprocess,threshold*G4UIcommand::ValueOf(unit.c_str()));
+            process,subprocess,
+            threshold*G4UIcommand::ValueOf(unit.c_str()),
+            category);
     }
     else if (command == fClearTrajectoryPointRulesCMD) {
         fPersistencyManager->ClearTrajectoryPointRules();

--- a/src/EDepSimPersistencyMessenger.hh
+++ b/src/EDepSimPersistencyMessenger.hh
@@ -40,8 +40,8 @@ private:
     G4UIcmdWithADoubleAndUnit* fTrajectoryPointDepositCMD;
     G4UIcmdWithAString*        fTrajectoryBoundaryCMD;
     G4UIcmdWithoutParameter*   fClearBoundariesCMD;
-    G4UIcommand*               fTrajectoryPointRuleCMD;
-    G4UIcmdWithoutParameter*   fClearTrajectoryPointRulesCMD;
+    G4UIcommand*               fTrajectoryRuleCMD;
+    G4UIcmdWithoutParameter*   fClearTrajectoryRulesCMD;
     G4UIcmdWithABool*          fSavePhotonTrajectoriesCMD;
 
 };

--- a/src/EDepSimTrajectory.cc
+++ b/src/EDepSimTrajectory.cc
@@ -44,8 +44,16 @@ EDepSim::Trajectory::Trajectory(const G4Event* theEvent,
     fPDGCharge = fpParticleDefinition->GetPDGCharge();
     fParticleName = fpParticleDefinition->GetParticleName();
     const G4VProcess* proc = aTrack->GetCreatorProcess();
-    if (proc) fProcessName = proc->GetProcessName();
-    else fProcessName = "primary";
+    if (proc) {
+        fProcessName = proc->GetProcessName();
+        fProcessType = proc->GetProcessType();
+        fProcessSubType = proc->GetProcessSubType();
+    }
+    else {
+        fProcessName = "primary";
+        fProcessType = -1;
+        fProcessSubType = -1;
+    }
     fInitialMomentum = aTrack->GetMomentum();
     fSDEnergyDeposit = 0.0;
     fSDTotalEnergyDeposit = 0.0;

--- a/src/EDepSimTrajectory.hh
+++ b/src/EDepSimTrajectory.hh
@@ -59,6 +59,12 @@ public:
     /// Get the interaction process that created the trajectory.
     inline G4String GetProcessName() const {return fProcessName;}
 
+    /// Get the interaction process type that created the trajectory.
+    inline G4int GetProcessType() const {return fProcessType;}
+
+    /// Get the interaction process sub-type that created the trajectory.
+    inline G4int GetProcessSubType() const {return fProcessSubType;}
+
     /// Get the initial momentum of the particle that created this trajectory.
     inline G4ThreeVector GetInitialMomentum() const {return fInitialMomentum;}
 
@@ -134,6 +140,8 @@ private:
     G4double                  fPDGCharge;
     G4String                  fParticleName;
     G4String                  fProcessName;
+    G4int                     fProcessType;
+    G4int                     fProcessSubType;
     G4ThreeVector             fInitialMomentum;
     G4double                  fSDEnergyDeposit;
     G4double                  fSDTotalEnergyDeposit;

--- a/validate/fast-tests/100TestTree.sh
+++ b/validate/fast-tests/100TestTree.sh
@@ -11,6 +11,11 @@ fi
 
 cat > 100TestTree.mac <<EOF
 #######################################
+# Test saving trajectory points
+#######################################
+/edep/db/set/trajectoryRule 2
+
+#######################################
 # Set the hit segment.
 #######################################
 /edep/hitSagitta drift 1.0 mm


### PR DESCRIPTION
Generalize and extend the /edep/db/set/trajectoryRule interface to also select if a trajectory should be saved.  This was suggested by Joel Elias since it greatly simplifies "empirically" determining the cross sections being used by GEANT4.    