### PR TITLE
Fix/remove unused root components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif(ROOT_FOUND)
 # Look for GEANT4.  If it's found, then build the simulation.
 # Otherwise, this can be skipped, but only the i/o library is built.
 if(NOT EDEPSIM_READONLY)
-  find_package(Geant4 10.0)
+  find_package(Geant4 11.0)
   if (Geant4_FOUND)
     include(${Geant4_USE_FILE})
   else (Geant4_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,14 @@ else(DOXYGEN_FOUND)
     COMMENT "Not generating API documentation with Doxygen" VERBATIM)
 endif(DOXYGEN_FOUND)
 
+# Collect which ROOT components are going to be needed
+set(EDEPSIM_ROOT_COMPONENTS Physics Matrix MathCore Tree RIO)
+if(EDEPSIM_DISPLAY)
+  set(EDEPSIM_ROOT_COMPONENTS Geom ${EDEPSIM_ROOT_COMPONENTS})
+endif(EDEPSIM_DISPLAY)
+
 # Make sure that ROOT is available.  ROOT is absolutely required.
-find_package(ROOT REQUIRED
-  COMPONENTS Geom Physics Matrix MathCore Tree RIO)
+find_package(ROOT REQUIRED COMPONENTS ${EDEPSIM_ROOT_COMPONENTS})
 if(ROOT_FOUND)
   include(${ROOT_USE_FILE})
 endif(ROOT_FOUND)


### PR DESCRIPTION
Remove the ROOT Geom component when it is not used, and bump the GEANT4 requirement to 11 (slightly unrelated, but 10 doesn't work).