### PR TITLE
Clean up ROOT geometry usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,14 +37,12 @@ else(DOXYGEN_FOUND)
     COMMENT "Not generating API documentation with Doxygen" VERBATIM)
 endif(DOXYGEN_FOUND)
 
-# Collect which ROOT components are going to be needed
-set(EDEPSIM_ROOT_COMPONENTS Physics Matrix MathCore Tree RIO)
-if(EDEPSIM_DISPLAY)
-  set(EDEPSIM_ROOT_COMPONENTS Geom ${EDEPSIM_ROOT_COMPONENTS})
-endif(EDEPSIM_DISPLAY)
-
 # Make sure that ROOT is available.  ROOT is absolutely required.
-find_package(ROOT REQUIRED COMPONENTS ${EDEPSIM_ROOT_COMPONENTS})
+# This will check for each of the components, and set
+# ROOT_<component>_FOUND if it is available.  Note that Physics,
+# Matrix, MathCore, Tree and RIO are required.  Geom must be found if
+# the event display will be built.
+find_package(ROOT REQUIRED COMPONENTS Geom Physics Matrix MathCore Tree RIO)
 if(ROOT_FOUND)
   include(${ROOT_USE_FILE})
 endif(ROOT_FOUND)
@@ -115,10 +113,12 @@ add_subdirectory(io)
 # Compile the really simple debugging display.  There are better
 # displays out there, but this is what I use to debug the code.  This
 # does not depend on geant4.
-if(EDEPSIM_DISPLAY)
+if(EDEPSIM_DISPLAY AND ROOT_geom_FOUND)
   message(STATUS "Building edep-disp event display")
   add_subdirectory(display)
-endif(EDEPSIM_DISPLAY)
+else()
+  message(WARNING "Event display will not be built")
+endif()
 
 # Only build the simulation if this is not being built in "READONLY" mode.
 if(NOT EDEPSIM_READONLY)

--- a/src/EDepSimHitSegment.cc
+++ b/src/EDepSimHitSegment.cc
@@ -4,7 +4,6 @@
 // Define a Hit to hold information about particles that hit the sensitive
 // detectors.
 
-#include "EDepSimRootGeometryManager.hh"
 #include "EDepSimHitSegment.hh"
 #include "EDepSimTrajectoryMap.hh"
 #include "EDepSimLog.hh"

--- a/src/EDepSimHitSurface.cc
+++ b/src/EDepSimHitSurface.cc
@@ -2,7 +2,6 @@
 // Define a to hold information about particles that hit a sensitive surface
 // (e.g. a photo cathode)
 
-#include "EDepSimRootGeometryManager.hh"
 #include "EDepSimHitSurface.hh"
 #include "EDepSimLog.hh"
 

--- a/src/EDepSimTrajectoryPoint.cc
+++ b/src/EDepSimTrajectoryPoint.cc
@@ -11,8 +11,6 @@
 #include <G4AttValue.hh>
 #include <G4UnitsTable.hh>
 
-#include <TGeoManager.h>
-
 #include <EDepSimLog.hh>
 
 G4Allocator<EDepSim::TrajectoryPoint> aTrajPointAllocator;

--- a/src/EDepSimTrajectoryPoint.cc
+++ b/src/EDepSimTrajectoryPoint.cc
@@ -1,4 +1,3 @@
-#include "EDepSimRootGeometryManager.hh"
 #include "EDepSimTrajectoryPoint.hh"
 
 #include <G4Track.hh>
@@ -172,13 +171,4 @@ std::vector<G4AttValue>* EDepSim::TrajectoryPoint::CreateAttValues() const {
 #endif
 
     return values;
-}
-
-int EDepSim::TrajectoryPoint::GetVolumeNode() const {
-    gGeoManager->PushPath();
-    int node
-        = EDepSim::RootGeometryManager::Get()->GetNodeId(0.5*(GetPosition()
-                                                          +fPrevPosition));
-    gGeoManager->PopPath();
-    return node;
 }

--- a/src/EDepSimTrajectoryPoint.hh
+++ b/src/EDepSimTrajectoryPoint.hh
@@ -65,11 +65,6 @@ public:
     /// referenced by GetVolumeNode().
     G4String GetPhysVolName() const { return fPhysVolName; }
 
-    /// Get the node for the volume containing the stopping point.  If the
-    /// stopping point is on a geometric boundary, this is the volume that the
-    /// track is just exiting.
-    int GetVolumeNode() const;
-
     /// Translate the step status into a printable name.
     G4String GetStepStatusName() const;
 

--- a/src/EDepSimUserEventAction.cc
+++ b/src/EDepSimUserEventAction.cc
@@ -1,6 +1,3 @@
-#include <TGeoManager.h>
-#include <TGeoNode.h>
-
 #include "EDepSimUserEventAction.hh"
 #include "EDepSimException.hh"
 #include "EDepSimUserEventInformation.hh"
@@ -8,7 +5,6 @@
 #include "EDepSimTrajectoryMap.hh"
 #include "EDepSimTrajectory.hh"
 #include "EDepSimHitSegment.hh"
-#include "EDepSimRootGeometryManager.hh"
 
 #include "EDepSimLog.hh"
 
@@ -37,25 +33,15 @@ void EDepSim::UserEventAction::BeginOfEventAction(const G4Event* theEvent) {
             SetUserInformation(new EDepSim::UserEventInformation);
     }
 
-    if (!gGeoManager) {
-        EDepSimError("The geometry manager is not defined.");
-        EDepSimThrow("Missing Geometry Manager");
-    }
-
     int vtxNumber=0;
     for (G4PrimaryVertex* vtx = theEvent->GetPrimaryVertex();
          vtx;
          vtx = vtx->GetNext()) {
         ++vtxNumber;
-        gGeoManager->PushPath();
-        EDepSim::RootGeometryManager::Get()->GetNodeId(
-            G4ThreeVector(vtx->GetX0(), vtx->GetY0(), vtx->GetZ0()));
         EDepSimNamedInfo(
             "Event",
             "Vertex: " << vtxNumber
-            << " w/ " << vtx->GetNumberOfParticle() << " primaries"
-            " in " << gGeoManager->GetPath());
-        gGeoManager->PopPath();
+            << " w/ " << vtx->GetNumberOfParticle() << " primaries");
         EDepSimNamedVerbose(
             "Event",
             "Position: "


### PR DESCRIPTION
Cleans up where (and when RootGeometryManager is used) so that only files directly using the geometry will be affected by it.  Also clean up how CMake handles the ROOT Geom component so that the build checks if it is present instead of just using it.