### PR TITLE
Add `G4CutTubs` shape conversion and allow unit strings given like `<value>*<unit>`

### DIFF
--- a/src/EDepSimRootGeometryManager.cc
+++ b/src/EDepSimRootGeometryManager.cc
@@ -44,6 +44,7 @@
 #include <G4Box.hh>
 #include <G4Trd.hh>
 #include <G4Tubs.hh>
+#include <G4CutTubs.hh>
 #include <G4Sphere.hh>
 #include <G4Polyhedra.hh>
 #include <G4Polycone.hh>
@@ -258,6 +259,23 @@ TGeoShape* EDepSim::RootGeometryManager::CreateShape(
         theShape = new TGeoTubeSeg(rmin, rmax,
                                    zhalf,
                                    minPhiDeg, maxPhiDeg);
+    }
+    else if (geometryType == "G4CutTubs") {
+        const G4CutTubs* tube = dynamic_cast<const G4CutTubs*>(theSolid);
+        // Root takes the angles in degrees so there is no extra
+        // conversion.  The cut-plane normals are unit vectors.
+        double zhalf = tube->GetZHalfLength()/CLHEP::mm;
+        double rmin = tube->GetInnerRadius()/CLHEP::mm;
+        double rmax = tube->GetOuterRadius()/CLHEP::mm;
+        double minPhiDeg = tube->GetStartPhiAngle()/CLHEP::degree;
+        double maxPhiDeg = minPhiDeg + tube->GetDeltaPhiAngle()/CLHEP::degree;
+        G4ThreeVector lowNorm = tube->GetLowNorm();
+        G4ThreeVector highNorm = tube->GetHighNorm();
+        theShape = new TGeoCtub(rmin, rmax,
+                                zhalf,
+                                minPhiDeg, maxPhiDeg,
+                                lowNorm.x(), lowNorm.y(), lowNorm.z(),
+                                highNorm.x(), highNorm.y(), highNorm.z());
     }
     else if (geometryType == "G4Sphere") {
         const G4Sphere* sphere = dynamic_cast<const G4Sphere*>(theSolid);

--- a/src/EDepSimUserDetectorConstruction.cc
+++ b/src/EDepSimUserDetectorConstruction.cc
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "EDepSimUserDetectorConstruction.hh"
 #include "EDepSimDetectorMessenger.hh"
 #include "EDepSimRootGeometryManager.hh"
@@ -112,6 +114,9 @@ namespace {
 
 namespace {
     double ParseUnit(std::string value, std::string unit) {
+        // Accept both "0.5 cm" and the "0.5*cm" form written by LArSoft
+        // geometry generators (eg dunecore GDML StepLimit auxiliaries).
+        std::replace(value.begin(), value.end(), '*', ' ');
         double val = 0.0;
         std::istringstream theStream(value);
         theStream >> val >> unit;


### PR DESCRIPTION
Two small additions needed to make the GMDL for LArSoft / ProtoDUNEs work.  Should not effect any existing users.